### PR TITLE
Functorized the unquote_term function

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -90,6 +90,25 @@ module Mindset = Names.Mindset
 type ('a,'b) sum =
   Left of 'a | Right of 'b
 
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance) kind_of_term =
+  | Coq_tRel of 'nat
+  | Coq_tVar of 'ident
+  | Coq_tMeta of 'nat
+  | Coq_tEvar of 'nat * 'term list
+  | Coq_tSort of 'quoted_sort
+  | Coq_tCast of 'term * 'cast_kind * 'term
+  | Coq_tProd of 'name * 'term * 'term
+  | Coq_tLambda of 'name * 'term * 'term
+  | Coq_tLetIn of 'name * 'term * 'term * 'term
+  | Coq_tApp of 'term * 'term list
+  | Coq_tConst of 'kername * 'universe_instance
+  | Coq_tInd of 'inductive * 'universe_instance
+  | Coq_tConstruct of 'inductive * 'nat * 'universe_instance
+  | Coq_tCase of ('inductive * 'nat) * 'term * 'term * ('nat * 'term) list
+  | Coq_tProj of 'projection * 'term
+  | Coq_tFix of term mfixpoint * 'nat
+  | Coq_tCoFix of term mfixpoint * 'nat
+      
 module type Quoter = sig
   type t
 
@@ -119,6 +138,8 @@ module type Quoter = sig
   type quoted_sort_family
 
   open Names
+  
+  
 
   val quote_ident : Id.t -> quoted_ident
   val quote_name : Name.t -> quoted_name

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -90,7 +90,7 @@ module Mindset = Names.Mindset
 type ('a,'b) sum =
   Left of 'a | Right of 'b
 
-type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance) kind_of_term =
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance, 'projection) kind_of_term =
   | Coq_tRel of 'nat
   | Coq_tVar of 'ident
   | Coq_tMeta of 'nat
@@ -106,8 +106,8 @@ type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive
   | Coq_tConstruct of 'inductive * 'nat * 'universe_instance
   | Coq_tCase of ('inductive * 'nat) * 'term * 'term * ('nat * 'term) list
   | Coq_tProj of 'projection * 'term
-  | Coq_tFix of term mfixpoint * 'nat
-  | Coq_tCoFix of term mfixpoint * 'nat
+  | Coq_tFix of (*term mfixpoint *) 'nat
+  | Coq_tCoFix of (*term mfixpoint *) 'nat
       
 module type Quoter = sig
   type t

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1880,7 +1880,7 @@ TACTIC EXTEND denote_term
          let env = Proofview.Goal.env gl in
          let evm = Proofview.Goal.sigma gl in
          let evdref = ref evm in
-         let c = Denote.denote_term evdref (EConstr.to_constr evm c) in
+         let c = TermReify.denote_term evdref (EConstr.to_constr evm c) in
          (* TODO : not the right way of retype things *)
          let def' = Constrextern.extern_constr true env !evdref (EConstr.of_constr c) in
          let def = Constrintern.interp_constr env !evdref def' in
@@ -1930,7 +1930,7 @@ VERNAC COMMAND EXTEND Unquote_vernac CLASSIFIED AS SIDEFF
 	let (evm, env) = Lemmas.get_current_context () in
 	let (trm, uctx) = Constrintern.interp_constr env evm def in
         let evdref = ref (Evd.from_ctx uctx) in
-	let trm = Denote.denote_term evdref trm in
+	let trm = TermReify.denote_term evdref trm in
 	let _ = Declare.declare_definition ~kind:Decl_kinds.Definition name (trm, Evd.universe_context_set !evdref) in
         () ]
 END;;

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -90,24 +90,28 @@ module Mindset = Names.Mindset
 type ('a,'b) sum =
   Left of 'a | Right of 'b
 
-type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance, 'projection) kind_of_term =
-  | Coq_tRel of 'nat
-  | Coq_tVar of 'ident
-  | Coq_tMeta of 'nat
-  | Coq_tEvar of 'nat * 'term list
-  | Coq_tSort of 'quoted_sort
-  | Coq_tCast of 'term * 'cast_kind * 'term
-  | Coq_tProd of 'name * 'term * 'term
-  | Coq_tLambda of 'name * 'term * 'term
-  | Coq_tLetIn of 'name * 'term * 'term * 'term
-  | Coq_tApp of 'term * 'term list
-  | Coq_tConst of 'kername * 'universe_instance
-  | Coq_tInd of 'inductive * 'universe_instance
-  | Coq_tConstruct of 'inductive * 'nat * 'universe_instance
-  | Coq_tCase of ('inductive * 'nat) * 'term * 'term * ('nat * 'term) list
-  | Coq_tProj of 'projection * 'term
-  | Coq_tFix of (*term mfixpoint *) 'nat
-  | Coq_tCoFix of (*term mfixpoint *) 'nat
+type ('term, 'name, 'nat) adef = { adname : 'name; adtype : 'term; adbody : 'term; rarg : 'nat }
+  
+type ('term, 'name, 'nat) amfixpoint = ('term, 'name, 'nat) adef list
+    
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance, 'projection) structure_of_term =
+  | ACoq_tRel of 'nat
+  | ACoq_tVar of 'ident
+  | ACoq_tMeta of 'nat
+  | ACoq_tEvar of 'nat * 'term list
+  | ACoq_tSort of 'quoted_sort
+  | ACoq_tCast of 'term * 'cast_kind * 'term
+  | ACoq_tProd of 'name * 'term * 'term
+  | ACoq_tLambda of 'name * 'term * 'term
+  | ACoq_tLetIn of 'name * 'term * 'term * 'term
+  | ACoq_tApp of 'term * 'term list
+  | ACoq_tConst of 'kername * 'universe_instance
+  | ACoq_tInd of 'inductive * 'universe_instance
+  | ACoq_tConstruct of 'inductive * 'nat * 'universe_instance
+  | ACoq_tCase of ('inductive * 'nat) * 'term * 'term * ('nat * 'term) list
+  | ACoq_tProj of 'projection * 'term
+  | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
+  | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
       
 module type Quoter = sig
   type t
@@ -201,6 +205,8 @@ module type Quoter = sig
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program
   val mkIn : t -> quoted_program
+
+  val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end
 
 (** The reifier to Coq values *)
@@ -658,6 +664,8 @@ struct
        let k = (quote_int (k - 1)) in
        Term.mkApp (tConstructRef, [|quote_inductive (kn ,n); k|])
 
+let inspectTerm (t:Term.constr) :  (Term.constr, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
+  failwith "not yet implemented"
 end
 
 

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -218,7 +218,7 @@ module type Quoter = sig
   (* val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
   val unquote_proj : quoted_proj -> (quoted_inductive * quoted_int * quoted_int)
   val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Univ.Universe.t
-  
+  val print_term : t -> Pp.std_ppcmds
   (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
   val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end
@@ -699,8 +699,9 @@ let inspectTerm (t:Term.constr) :  (Term.constr, quoted_int, quoted_ident, quote
       match args with
 	    x :: _ -> ACoq_tRel x
       | _ -> raise (Failure "ill-typed")
-    else raise (Failure "not yet implemented")
+    else failwith "not yet implemented"
 
+    let print_term (u: t) : Pp.std_ppcmds = Printer.pr_constr u
 
     let rec unquote_int trm =
       let (h,args) = app_full trm [] in
@@ -1337,9 +1338,9 @@ struct
         ACoq_tApp (f, xs) -> app_full_abs f (xs @ acc)
       | _ -> (trm, acc)
     
-    let str_abs (t: Q.t) : Pp.std_ppcmds = failwith "not yet implemented: str_abs"
+    let str_abs (t: Q.t) : Pp.std_ppcmds = Q.print_term t (* unfold this defn everywhere and delete*)
     let not_supported_verb (t: Q.t) s = CErrors.user_err (Pp.(str_abs t ++ Pp.str s))
-    let bad_term (t: Q.t) = not_supported_verb t "bad_term is not yet implemented" 
+    let bad_term (t: Q.t) = not_supported_verb t "bad_term" 
           
   (** NOTE: Because the representation is lossy, I should probably
    ** come back through elaboration.

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -760,7 +760,7 @@ struct
   else if Term.eq_constr h tConstructor then
     match args with
       i::idx::u::_ -> ACoq_tConstruct (i,idx,u)
-      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure"))
+      | _ -> CErrors.user_err (print_term t ++ Pp.str ("has bad structure: constructor case"))
   else if Term.eq_constr h tCase then
     match args with
       info::ty::d::brs::_ -> ACoq_tCase (from_coq_pair info, ty, d, List.map from_coq_pair (from_coq_list brs))

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -1,6 +1,29 @@
 type ('a,'b) sum =
   Left of 'a | Right of 'b
 
+type ('term, 'name, 'nat) adef = { adname : 'name; adtype : 'term; adbody : 'term; rarg : 'nat }
+
+type ('term, 'name, 'nat) amfixpoint = ('term, 'name, 'nat) adef list
+
+type ('term, 'nat, 'ident, 'name, 'quoted_sort, 'cast_kind, 'kername, 'inductive, 'universe_instance, 'projection) structure_of_term =
+  | ACoq_tRel of 'nat
+  | ACoq_tVar of 'ident
+  | ACoq_tMeta of 'nat
+  | ACoq_tEvar of 'nat * 'term list
+  | ACoq_tSort of 'quoted_sort
+  | ACoq_tCast of 'term * 'cast_kind * 'term
+  | ACoq_tProd of 'name * 'term * 'term
+  | ACoq_tLambda of 'name * 'term * 'term
+  | ACoq_tLetIn of 'name * 'term * 'term * 'term
+  | ACoq_tApp of 'term * 'term list
+  | ACoq_tConst of 'kername * 'universe_instance
+  | ACoq_tInd of 'inductive * 'universe_instance
+  | ACoq_tConstruct of 'inductive * 'nat * 'universe_instance
+  | ACoq_tCase of ('inductive * 'nat) * 'term * 'term * ('nat * 'term) list
+  | ACoq_tProj of 'projection * 'term
+  | ACoq_tFix of ('term, 'name, 'nat) amfixpoint * 'nat
+  | ACoq_tCoFix of ('term, 'name, 'nat) amfixpoint * 'nat
+
 module type Quoter = sig
   type t
 
@@ -91,6 +114,7 @@ module type Quoter = sig
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program
   val mkIn : t -> quoted_program
+  val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end
 
 module Reify(Q : Quoter) : sig

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -42,10 +42,11 @@ module type Quoter = sig
   type quoted_univ_instance
   type quoted_univ_constraints
   type quoted_univ_context
+  type quoted_inductive_universes
   type quoted_mind_params
   type quoted_ind_entry =
     quoted_ident * t * quoted_bool * quoted_ident list * t list
-  type quoted_definition_entry = t * t option
+  type quoted_definition_entry = t * t option * quoted_univ_context
   type quoted_mind_entry
   type quoted_mind_finiteness
   type quoted_entry
@@ -69,14 +70,15 @@ module type Quoter = sig
   val quote_univ_constraints : Univ.Constraint.t -> quoted_univ_constraints
   val quote_univ_context : Univ.UContext.t -> quoted_univ_context
   val quote_abstract_univ_context : Univ.AUContext.t -> quoted_univ_context
+  val quote_inductive_universes : Entries.inductive_universes -> quoted_inductive_universes
+  val quote_mind_params : (quoted_ident * (t,t) sum) list -> quoted_mind_params
+  val quote_mind_finiteness : Decl_kinds.recursivity_kind -> quoted_mind_finiteness
+  val quote_mutual_inductive_entry :
+    quoted_mind_finiteness * quoted_mind_params * quoted_ind_entry list *
+    quoted_inductive_universes ->
+    quoted_mind_entry
 
-  (* val quote_mind_params : (quoted_ident * (t,t) sum) list -> quoted_mind_params *)
-  (* val quote_mind_finiteness : Decl_kinds.recursivity_kind -> quoted_mind_finiteness *)
-  (* val quote_mutual_inductive_entry : *)
-  (*   quoted_mind_finiteness * quoted_mind_params * quoted_ind_entry list * quoted_bool -> *)
-  (*   quoted_mind_entry *)
-
-  (* val quote_entry : (quoted_definition_entry, quoted_mind_entry) sum option -> quoted_entry *)
+  val quote_entry : (quoted_definition_entry, quoted_mind_entry) sum option -> quoted_entry
   val quote_proj : quoted_inductive -> quoted_int -> quoted_int -> quoted_proj
 
   val mkName : quoted_ident -> quoted_name

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -126,7 +126,8 @@ module type Quoter = sig
   (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
   val unquote_proj : quoted_proj -> (quoted_inductive * quoted_int * quoted_int)
   val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Univ.Universe.t
-  
+  val print_term : t -> Pp.std_ppcmds
+
   (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
   val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -114,7 +114,20 @@ module type Quoter = sig
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program
   val mkIn : t -> quoted_program
-  val representsIndConstuctor : quoted_inductive -> Term.constr -> bool
+  val unquote_ident : quoted_ident -> Id.t
+  val unquote_name : quoted_name -> Name.t
+  val unquote_int :  quoted_int -> int
+  val unquote_bool : quoted_bool -> bool
+  (* val unquote_sort : quoted_sort -> Sorts.t *)
+  (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
+  val unquote_cast_kind : quoted_cast_kind -> Constr.cast_kind
+  val unquote_kn :  quoted_kernel_name -> Libnames.qualid
+  val unquote_inductive :  quoted_inductive -> Names.inductive
+  (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
+  val unquote_proj : quoted_proj -> (quoted_inductive * quoted_int * quoted_int)
+  val unquote_universe : Evd.evar_map -> quoted_sort -> Evd.evar_map * Univ.Universe.t
+  
+  (* val representsIndConstuctor : quoted_inductive -> Term.constr -> bool *)
   val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end
 

--- a/src/reify.mli
+++ b/src/reify.mli
@@ -114,6 +114,7 @@ module type Quoter = sig
 
   val mkExt : quoted_decl -> quoted_program -> quoted_program
   val mkIn : t -> quoted_program
+  val representsIndConstuctor : quoted_inductive -> Term.constr -> bool
   val inspectTerm : t -> (t, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term
 end
 

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -256,6 +256,8 @@ struct
     = failwith "not yet implemented"
   let unquote_universe (q: Evd.evar_map) (qs: quoted_sort) : Evd.evar_map * Univ.Universe.t
   = failwith "not yet implemented"
+  let print_term  (u: t) : Pp.std_ppcmds = failwith "not yet implemented"
+
 end
 
 

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -308,18 +308,17 @@ struct
     (ind, ps, idx)
 
   let unquote_level (trm : Univ0.Level.t) : Univ.Level.t =
-    let open Univ0.Level in
     match trm with
-    | Coq_lProp -> Univ.Level.prop
-    | Coq_lSet -> Univ.Level.set
-    | Level s ->
+    | Univ0.Level.Coq_lProp -> Univ.Level.prop
+    | Univ0.Level.Coq_lSet -> Univ.Level.set
+    | Univ0.Level.Level s ->
       let s = unquote_string s in
       let comps = String.split_on_char '.' s in
       let last, dp = CList.sep_last comps in
       let dp = DirPath.make (List.map Id.of_string comps) in
       let idx = int_of_string last in
       Univ.Level.make dp idx
-    | Var n -> Univ.Level.var (unquote_int n)
+    | Univ0.Level.Var n -> Univ.Level.var (unquote_int n)
 
   let unquote_level_expr (trm : Univ0.Level.t) (b : quoted_bool) : Univ.Universe.t =
     let l = unquote_level trm in

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -236,11 +236,26 @@ struct
        Some (Right mind_entry)
     | None -> None
 
-    let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
-     match t with
-    | Coq_tRel n -> ACoq_tRel n
+  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
+   match t with
+  | Coq_tRel n -> ACoq_tRel n
     (* so on *)
-    | _ ->  failwith "not yet implemented"
+  | _ ->  failwith "not yet implemented"
+
+  let unquote_ident (qi: quoted_ident) : Id.t = failwith "not yet implemented"
+  let unquote_name (q: quoted_name) : Name.t = failwith "not yet implemented"
+  let unquote_int (q: quoted_int) : int = failwith "not yet implemented"
+  let unquote_bool (q : quoted_bool) : bool = failwith "not yet implemented"
+  (* val unquote_sort : quoted_sort -> Sorts.t *)
+  (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
+  let unquote_cast_kind (q : quoted_cast_kind) : Constr.cast_kind = failwith "not yet implemented"
+  let unquote_kn (q: quoted_kernel_name) : Libnames.qualid = failwith "not yet implemented"
+  let unquote_inductive (q: quoted_inductive) : Names.inductive = failwith "not yet implemented"
+  (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
+  let unquote_proj (q : quoted_proj) : (quoted_inductive * quoted_int * quoted_int)
+    = failwith "not yet implemented"
+  let unquote_universe (q: Evd.evar_map) (qs: quoted_sort) : Evd.evar_map * Univ.Universe.t
+  = failwith "not yet implemented"
 end
 
 

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -236,10 +236,11 @@ struct
        Some (Right mind_entry)
     | None -> None
 
-  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
-    (* match t with
-    | Coq_tRel n -> Coq_tRel n
-    | _ -> *) failwith "not yet implemented"
+    let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
+     match t with
+    | Coq_tRel n -> ACoq_tRel n
+    (* so on *)
+    | _ ->  failwith "not yet implemented"
 end
 
 

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -295,7 +295,7 @@ struct
 
   let unquote_inductive (q: quoted_inductive) : Names.inductive =
     let { inductive_mind = na; inductive_ind = i } = q in
-    let comps = String.split_on_char '.' (unquote_string na) in
+    let comps = CString.split '.' (unquote_string na) in
     let comps = List.map Id.of_string comps in
     let id, dp = CList.sep_last comps in
     let dp = DirPath.make dp in
@@ -313,7 +313,7 @@ struct
     | Univ0.Level.Coq_lSet -> Univ.Level.set
     | Univ0.Level.Level s ->
       let s = unquote_string s in
-      let comps = String.split_on_char '.' s in
+      let comps = CString.split '.' s in
       let last, dp = CList.sep_last comps in
       let dp = DirPath.make (List.map Id.of_string comps) in
       let idx = int_of_string last in

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -196,46 +196,53 @@ struct
 
   let mkIn c = PIn c
 
-  (* let quote_mind_finiteness = function *)
-  (*   | Decl_kinds.Finite -> Finite *)
-  (*   | Decl_kinds.CoFinite -> CoFinite *)
-  (*   | Decl_kinds.BiFinite -> BiFinite *)
+  let quote_mind_finiteness = function
+    | Decl_kinds.Finite -> Finite
+    | Decl_kinds.CoFinite -> CoFinite
+    | Decl_kinds.BiFinite -> BiFinite
 
-  (* let quote_mind_params l = *)
-  (*   let map (id, body) = *)
-  (*     match body with *)
-  (*     | Left ty -> (id, LocalAssum ty) *)
-  (*     | Right trm -> (id, LocalDef trm) *)
-  (*   in List.map map l *)
+  let quote_mind_params l =
+    let map (id, body) =
+      match body with
+      | Left ty -> (id, LocalAssum ty)
+      | Right trm -> (id, LocalDef trm)
+    in List.map map l
 
-  (* let quote_one_inductive_entry (id, ar, b, consnames, constypes) = *)
-  (*   { mind_entry_typename = id; *)
-  (*     mind_entry_arity = ar; *)
-  (*     mind_entry_template = b; *)
-  (*     mind_entry_consnames = consnames; *)
-  (*     mind_entry_lc = constypes } *)
+  let quote_one_inductive_entry (id, ar, b, consnames, constypes) =
+    { mind_entry_typename = id;
+      mind_entry_arity = ar;
+      mind_entry_template = b;
+      mind_entry_consnames = consnames;
+      mind_entry_lc = constypes }
 
-  (* let quote_mutual_inductive_entry (mf, mp, is, poly, univs) = *)
-  (*   { mind_entry_record = None; *)
-  (*     mind_entry_finite = mf; *)
-  (*     mind_entry_params = mp; *)
-  (*     mind_entry_inds = List.map quote_one_inductive_entry is; *)
-  (*     mind_entry_polymorphic = poly; *)
-  (*     mind_entry_universes = univs; *)
-  (*     mind_entry_private = None } *)
+  let quote_mutual_inductive_entry (mf, mp, is, poly, univs) =
+    { mind_entry_record = None;
+      mind_entry_finite = mf;
+      mind_entry_params = mp;
+      mind_entry_inds = List.map quote_one_inductive_entry is;
+      mind_entry_polymorphic = poly;
+      mind_entry_universes = univs;
+      mind_entry_private = None }
 
-  (* let quote_entry e = *)
-  (*   match e with *)
-  (*   | Some (Left (ty, body)) -> *)
-  (*      let entry = match body with *)
-  (*       | None -> ParameterEntry ty *)
-  (*       | Some b -> DefinitionEntry { definition_entry_type = ty; *)
-  (*                                     definition_entry_body = b } *)
-  (*      in Some (Left entry) *)
-  (*   | Some (Right mind_entry) -> *)
-  (*      Some (Right mind_entry) *)
-  (*   | None -> None *)
+  let quote_entry e =
+    match e with
+    | Some (Left (ty, body)) ->
+       let entry = match body with
+        | None -> ParameterEntry ty
+        | Some b -> DefinitionEntry { definition_entry_type = ty;
+                                      definition_entry_body = b }
+       in Some (Left entry)
+    | Some (Right mind_entry) ->
+       Some (Right mind_entry)
+    | None -> None
+
+  let inspectTerm (t : term) :  (term, quoted_int, quoted_ident, quoted_name, quoted_sort, quoted_cast_kind, quoted_kernel_name, quoted_inductive, quoted_univ_instance, quoted_proj) structure_of_term =
+    (* match t with
+    | Coq_tRel n -> Coq_tRel n
+    | _ -> *) failwith "not yet implemented"
 end
+
+
 
 module TemplateASTReifier = Reify(TemplateASTQuoter)
 

--- a/src/template_coq.ml4
+++ b/src/template_coq.ml4
@@ -13,6 +13,16 @@ let quote_string s =
     else aux (s.[i] :: acc) (i - 1)
   in aux [] (String.length s - 1)
 
+let unquote_string l =
+  let buf = Bytes.create (List.length l) in
+  let rec aux i = function
+    | [] -> ()
+    | c :: cs ->
+      Bytes.set buf i c; aux (succ i) cs
+  in
+  aux 0 l;
+  Bytes.to_string buf
+
 module TemplateASTQuoter =
 struct
   type t = term
@@ -31,10 +41,11 @@ struct
   type quoted_univ_instance = Univ0.Instance.t
   type quoted_univ_constraints = Univ0.constraints
   type quoted_univ_context = Univ0.universe_context
+  type quoted_inductive_universes = quoted_univ_context
   type quoted_mind_params = (ident * local_entry) list
   type quoted_ind_entry =
     quoted_ident * t * quoted_bool * quoted_ident list * t list
-  type quoted_definition_entry = t * t option
+  type quoted_definition_entry = t * t option * quoted_univ_context
   type quoted_mind_entry = mutual_inductive_entry
   type quoted_mind_finiteness = recursivity_kind
   type quoted_entry = (constant_entry, quoted_mind_entry) sum option
@@ -73,10 +84,6 @@ struct
                        let b' = quote_bool (Univ.Universe.exists (fun (l2,i) -> Univ.Level.equal l l2 && i = 1) s) in
                        (l', b'))
              levels
-
-  let quote_univ_instance u =
-    let arr = Univ.Instance.to_array u in
-    CArray.map_to_list quote_level arr
 
   let quote_sort s =
     quote_universe (Sorts.univ_of_sort s)
@@ -124,7 +131,8 @@ struct
     ((quote_level l, quote_constraint_type ct), quote_level l')
 
   let quote_univ_instance (i : Univ.Instance.t) : quoted_univ_instance =
-    CArray.map_to_list quote_level (Univ.Instance.to_array i)
+    let arr = Univ.Instance.to_array i in
+    CArray.map_to_list quote_level arr
 
   let quote_univ_constraints (c : Univ.Constraint.t) : quoted_univ_constraints =
     List.map quote_univ_constraint (Univ.Constraint.elements c)
@@ -134,11 +142,20 @@ struct
     let constraints = Univ.UContext.constraints uctx in
     Univ0.Monomorphic_ctx (quote_univ_instance levels, quote_univ_constraints constraints)
 
-  let quote_abstract_univ_context (uctx : Univ.AUContext.t) : quoted_univ_context =
-    let uctx = Univ.AUContext.repr uctx in
+  let quote_abstract_univ_context_aux uctx : quoted_univ_context =
     let levels = Univ.UContext.instance uctx in
     let constraints = Univ.UContext.constraints uctx in
     Univ0.Polymorphic_ctx (quote_univ_instance levels, quote_univ_constraints constraints)
+
+  let quote_abstract_univ_context (uctx : Univ.AUContext.t) =
+    let uctx = Univ.AUContext.repr uctx in
+    quote_abstract_univ_context_aux uctx
+
+  let quote_inductive_universes = function
+    | Entries.Monomorphic_ind_entry ctx -> quote_univ_context ctx
+    | Entries.Polymorphic_ind_entry ctx -> quote_abstract_univ_context_aux ctx
+    | Entries.Cumulative_ind_entry ctx ->
+      quote_abstract_univ_context_aux (Univ.CumulativityInfo.univ_context ctx)
 
   let rec seq f t =
     if f < t then
@@ -215,22 +232,24 @@ struct
       mind_entry_consnames = consnames;
       mind_entry_lc = constypes }
 
-  let quote_mutual_inductive_entry (mf, mp, is, poly, univs) =
+  let quote_mutual_inductive_entry (mf, mp, is, univs) =
     { mind_entry_record = None;
       mind_entry_finite = mf;
       mind_entry_params = mp;
       mind_entry_inds = List.map quote_one_inductive_entry is;
-      mind_entry_polymorphic = poly;
       mind_entry_universes = univs;
       mind_entry_private = None }
 
   let quote_entry e =
     match e with
-    | Some (Left (ty, body)) ->
+    | Some (Left (ty, body, ctx)) ->
        let entry = match body with
-        | None -> ParameterEntry ty
+         | None -> ParameterEntry { parameter_entry_type = ty;
+                                    parameter_entry_universes = ctx }
         | Some b -> DefinitionEntry { definition_entry_type = ty;
-                                      definition_entry_body = b }
+                                      definition_entry_body = b;
+                                      definition_entry_universes = ctx;
+                                      definition_entry_opaque = false }
        in Some (Left entry)
     | Some (Right mind_entry) ->
        Some (Right mind_entry)
@@ -242,20 +261,80 @@ struct
     (* so on *)
   | _ ->  failwith "not yet implemented"
 
-  let unquote_ident (qi: quoted_ident) : Id.t = failwith "not yet implemented"
-  let unquote_name (q: quoted_name) : Name.t = failwith "not yet implemented"
-  let unquote_int (q: quoted_int) : int = failwith "not yet implemented"
-  let unquote_bool (q : quoted_bool) : bool = failwith "not yet implemented"
+
+
+
+  let unquote_ident (qi: quoted_ident) : Id.t =
+    let s = unquote_string qi in
+    Id.of_string s
+
+  let unquote_name (q: quoted_name) : Name.t =
+    match q with
+    | Coq_nAnon -> Anonymous
+    | Coq_nNamed n -> Name (unquote_ident n)
+
+  let rec unquote_int (q: quoted_int) : int =
+    match q with
+    | Datatypes.O -> 0
+    | Datatypes.S x -> succ (unquote_int x)
+
+  let unquote_bool (q : quoted_bool) : bool = q
+
   (* val unquote_sort : quoted_sort -> Sorts.t *)
   (* val unquote_sort_family : quoted_sort_family -> Sorts.family *)
-  let unquote_cast_kind (q : quoted_cast_kind) : Constr.cast_kind = failwith "not yet implemented"
-  let unquote_kn (q: quoted_kernel_name) : Libnames.qualid = failwith "not yet implemented"
-  let unquote_inductive (q: quoted_inductive) : Names.inductive = failwith "not yet implemented"
+  let unquote_cast_kind (q : quoted_cast_kind) : Constr.cast_kind =
+    match q with
+    | VmCast -> VMcast
+    | NativeCast -> NATIVEcast
+    | Cast -> DEFAULTcast
+    | RevertCast -> REVERTcast
+
+  let unquote_kn (q: quoted_kernel_name) : Libnames.qualid =
+    let s = unquote_string q in
+    Libnames.qualid_of_string s
+
+  let unquote_inductive (q: quoted_inductive) : Names.inductive =
+    let { inductive_mind = na; inductive_ind = i } = q in
+    let comps = String.split_on_char '.' (unquote_string na) in
+    let comps = List.map Id.of_string comps in
+    let id, dp = CList.sep_last comps in
+    let dp = DirPath.make dp in
+    let mind = Globnames.encode_mind dp id in
+    (mind, unquote_int i)
+
   (*val unquote_univ_instance :  quoted_univ_instance -> Univ.Instance.t *)
-  let unquote_proj (q : quoted_proj) : (quoted_inductive * quoted_int * quoted_int)
-    = failwith "not yet implemented"
-  let unquote_universe (q: Evd.evar_map) (qs: quoted_sort) : Evd.evar_map * Univ.Universe.t
-  = failwith "not yet implemented"
+  let unquote_proj (q : quoted_proj) : (quoted_inductive * quoted_int * quoted_int) =
+    let (ind, ps), idx = q in
+    (ind, ps, idx)
+
+  let unquote_level (trm : Univ0.Level.t) : Univ.Level.t =
+    let open Univ0.Level in
+    match trm with
+    | Coq_lProp -> Univ.Level.prop
+    | Coq_lSet -> Univ.Level.set
+    | Level s ->
+      let s = unquote_string s in
+      let comps = String.split_on_char '.' s in
+      let last, dp = CList.sep_last comps in
+      let dp = DirPath.make (List.map Id.of_string comps) in
+      let idx = int_of_string last in
+      Univ.Level.make dp idx
+    | Var n -> Univ.Level.var (unquote_int n)
+
+  let unquote_level_expr (trm : Univ0.Level.t) (b : quoted_bool) : Univ.Universe.t =
+    let l = unquote_level trm in
+    let u = Univ.Universe.make l in
+    if b then Univ.Universe.super u
+    else u
+
+  let unquote_universe evd (trm : Univ0.Universe.t) =
+    match trm with
+    | [] -> Evd.new_univ_variable (Evd.UnivFlexible false) evd
+    | (l,b)::q ->
+      evd, List.fold_left (fun u (l,b) ->
+          let u' = unquote_level_expr l b in Univ.Universe.sup u u')
+        (unquote_level_expr l b) q
+
   let print_term  (u: t) : Pp.std_ppcmds = failwith "not yet implemented"
 
 end

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -69,9 +69,11 @@ Quote Definition eo_syntax := Eval compute in even.
 
 Quote Definition add'_syntax := Eval compute in add'.
 
-(** Reflecting definitions **)
-Make Definition zero_from_syntax := (Ast.tConstruct (Ast.mkInd "Coq.Init.Datatypes.nat" 0) 0).
 
+(** Reflecting definitions **)
+Make Definition zero_from_syntax := (Ast.tConstruct (Ast.mkInd "Coq.Init.Datatypes.nat" 0) 0 []).
+
+(* the function unquote_kn in reify.ml4 is not yet implemented *)
 Make Definition add_from_syntax := ltac:(let t:= eval compute in add_syntax in exact t).
 
 Make Definition eo_from_syntax :=

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -138,7 +138,6 @@ Definition mut_i : mutual_inductive_entry :=
   mind_entry_finite := Finite;
   mind_entry_params := [];
   mind_entry_inds := [one_i; one_i2];
-  mind_entry_polymorphic := false;
   mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
   mind_entry_private := None;
 |}.
@@ -166,7 +165,6 @@ Definition mut_list_i : mutual_inductive_entry :=
   mind_entry_finite := Finite;
   mind_entry_params := [("A", LocalAssum (tSort Universe.type0))];
   mind_entry_inds := [one_list_i];
-  mind_entry_polymorphic := false;
   mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
   mind_entry_private := None;
 |}.
@@ -192,7 +190,6 @@ Definition mut_pt_i : mutual_inductive_entry :=
   mind_entry_finite := BiFinite;
   mind_entry_params := [("A", LocalAssum (tSort Universe.type0))];
   mind_entry_inds := [one_pt_i];
-  mind_entry_polymorphic := false;
   mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
   mind_entry_private := None;
 |}.

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -370,7 +370,6 @@ Make Definition myProp := (tSort [(Level.lProp, false)]).
 Make Definition myProp' := Eval compute in (tSort Universe.type0m).
 Make Definition mySucProp := (tSort [(Level.lProp, true)]).
 Make Definition mySet := (tSort [(Level.lSet, false)]).
-Print Universes.
 
 (** Cofixpoints *)
 CoInductive streamn : Set :=

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -8,7 +8,7 @@ Set Printing Universes.
 
 Inductive foo (A : Type) : Type :=
 | fooc : list A -> foo A.
-Print Universes.
+(* Print Universes.*)
 (* Top.1 <= Coq.Init.Datatypes.44 *)
 
 Quote Recursively Definition qfoo := foo.
@@ -17,10 +17,10 @@ Compute qfoo.
 Polymorphic Inductive foo2 (A : Type) : Type :=
 | fooc2 : list A -> foo2 A.
 (* Top.4 |= Top.4 <= Coq.Init.Datatypes.44 *)
-Print Universes.
+(* Print Universes.*)
 
 Definition foo2_instance := foo2.
-Print Universes.
+(* Print Universes.*)
 (* Top.9 <= Coq.Init.Datatypes.44 *)
 
 Quote Recursively Definition qfoo2 := foo2.
@@ -75,7 +75,7 @@ Monomorphic Universe i j.
 Definition test := (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
 Set Printing Universes.
 Print test.
-Print Universes.
+(* Print Universes. *)
 Unset Printing Universes. 
 
 Quote Definition qtest := Eval compute in (fun (T : Type@{i}) (T2 : Type@{j}) => T -> T2).
@@ -87,7 +87,7 @@ Make Definition bla' := (tLambda (nNamed "T") (tSort ((Level.Level "Top.2", fals
 Set Printing Universes.
 Print bla.
 Print bla'.
-Print Universes.
+(* Print Universes. *)
 Unset Printing Universes.
 
 Set Universe Polymorphism.
@@ -131,4 +131,4 @@ Make Definition t2 := (Ast.tLambda (Ast.nNamed "T") (Ast.tSort [(Level.Level "To
                                    (Ast.tLambda (Ast.nNamed "T2") (Ast.tSort [(Level.Level "Top.10002", false)]) (Ast.tProd Ast.nAnon (Ast.tRel 1) (Ast.tRel 1)))).
 Set Printing Universes.
 Print t2.
-Print Universes.
+(* Print Universes. *)

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -112,14 +112,14 @@ Inductive recursivity_kind :=
 Record definition_entry := {
   definition_entry_type : term;
   definition_entry_body : term;
-  definition_entry_polymorphic : bool;
   definition_entry_universes   : universe_context;
   definition_entry_opaque      : bool;
  }.
 
 
-Record parameter_entry : Set := {
-  parameter_entry_type : term }.
+Record parameter_entry := {
+  parameter_entry_type : term;
+  parameter_entry_universes : universe_context }.
 
 Inductive constant_entry :=
 | ParameterEntry (p : parameter_entry)
@@ -130,7 +130,6 @@ Record mutual_inductive_entry := {
   mind_entry_finite : recursivity_kind;
   mind_entry_params : list (ident * local_entry);
   mind_entry_inds : list one_inductive_entry;
-  mind_entry_polymorphic : bool; 
   mind_entry_universes : universe_context;
   mind_entry_private : option bool
 }.

--- a/theories/AstUtils.v
+++ b/theories/AstUtils.v
@@ -71,7 +71,6 @@ Proof.
             mind_entry_finite := Finite; (* inductive *)
             mind_entry_params := _;
             mind_entry_inds := _;
-            mind_entry_polymorphic := _;
             mind_entry_universes := decl.(ind_universes);
             mind_entry_private := None |}.
   - refine (match List.hd_error decl.(ind_bodies) with
@@ -96,12 +95,4 @@ Proof.
     refine (List.map (fun x => fst (fst x)) ind_ctors).
     refine (List.map (fun x => remove_arity decl.(ind_npars)
                                                 (snd (fst x))) ind_ctors).
-  - refine (let '(levels, constraints) := uGraph.repr decl.(ind_universes) in
-            let not_var := fun l => match l with
-                                 | Level.Var _  => false
-                                 | _ => true
-                                 end in
-            List.forallb not_var levels
-           && Constraint.for_all (fun '((l, _), l') => not_var l && not_var l')
-           constraints).
 Defined.

--- a/theories/kernel/univ.v
+++ b/theories/kernel/univ.v
@@ -101,7 +101,7 @@ End Level.
 Require FSets.FSetWeakList.
 Require FSets.FMapWeakList.
 Module LevelDecidableType.
-   Definition t : Type := Level.t.
+   Definition t : Set := Level.t.
    Definition eq : t -> t -> Prop := eq.
    Definition eq_refl : forall x : t, eq x x := @eq_refl _.
    Definition eq_sym : forall x y : t, eq x y -> eq y x := @eq_sym _.
@@ -276,7 +276,7 @@ Definition make_univ_constraint : universe_level -> constraint_type -> universe_
 
 Require MSets.MSetWeakList.
 Module ConstraintTypeDec.
-  Definition t := univ_constraint.
+  Definition t : Set := univ_constraint.
   Definition eq : t -> t -> Prop := eq.
   Definition eq_equiv : RelationClasses.Equivalence eq := _.
   Definition eq_dec : forall x y : t, {eq x y} + {~ eq x y}.
@@ -285,7 +285,9 @@ Module ConstraintTypeDec.
 End ConstraintTypeDec.
 Module Constraint := MSets.MSetWeakList.Make ConstraintTypeDec.
 
-Definition constraints := Constraint.t.  (* list univ_constraint *)
+(** Needs to be in Type because template polymorphism of MSets does not allow setting
+    the lowest universe *)
+Definition constraints : Type := Constraint.t.  (* list univ_constraint *)
 
 (* val empty_constraint : constraints *)
 (* val union_constraint : constraints -> constraints -> constraints *)
@@ -322,7 +324,7 @@ Definition constraint_function A : Type := A -> A -> constraints -> constraints.
 
 Module Instance.
 
-  Definition t := list Level.t.
+  Definition t : Set := list Level.t.
   (** A universe instance represents a vector of argument universes
       to a polymorphic definition (constant, inductive or constructor). *)
 

--- a/translations/tsl_param.v
+++ b/translations/tsl_param.v
@@ -1,305 +1,297 @@
+(* -*- coq-prog-args: ("-type-in-type" "-top" "Translations.tsl_param") -*-  *)
 Require Import Template.All.
-Require Import Arith.Compare_dec.
-From Translations Require Import translation_utils.
-Import String List Lists.List.ListNotations MonadNotation.
-Open Scope list_scope.
-Open Scope string_scope.
+From Translations Require Import translation_utils sigma.
+Import String Lists.List.ListNotations MonadNotation.
+Open Scope list_scope. Open Scope string_scope. Open Scope sigma_scope.
 
-Infix "<=" := Nat.leb.
 
-Definition default_term := tVar "constant_not_found".
-Definition debug_term msg:= tVar ("debug: " ++ msg).
+Reserved Notation "'tsl_ty_param'".
 
-Fixpoint tsl_rec0 (n : nat) (t : term) {struct t} : term :=
+Fixpoint refresh_universes (t : term) {struct t} :=
   match t with
-  | tRel k => if n <= k then tRel (2*k-n+1) else t
-  | tEvar k ts => tEvar k (map (tsl_rec0 n) ts)
-  | tCast t c a => tCast (tsl_rec0 n t) c (tsl_rec0 n a)
-  | tProd na A B => tProd na (tsl_rec0 n A) (tsl_rec0 (n+1) B)
-  | tLambda na A t => tLambda na (tsl_rec0 n A) (tsl_rec0 (n+1) t)
-  | tLetIn na t A u => tLetIn na (tsl_rec0 n t) (tsl_rec0 n A) (tsl_rec0 (n+1) u)
-  | tApp t lu => tApp (tsl_rec0 n t) (map (tsl_rec0 n) lu)
-  | tCase ik t u br => tCase ik (tsl_rec0 n t) (tsl_rec0 n u)
-                            (map (fun x => (fst x, tsl_rec0 n (snd x))) br)
-  | tProj p t => tProj p (tsl_rec0 n t)
-  (* | tFix : mfixpoint term -> nat -> term *)
-  (* | tCoFix : mfixpoint term -> nat -> term *)
+  | tSort s => tSort []
+  | tProd na b t => tProd na b (refresh_universes t)
+  | tLetIn na b t' t => tLetIn na b t' (refresh_universes t)
   | _ => t
   end.
 
-Fixpoint tsl_rec1_app (app : option term) (E : tsl_table) (t : term) : term :=
-  let tsl_rec1 := tsl_rec1_app None in
-  let debug case symbol :=
-      debug_term ("tsl_rec1: " ++ case ++ " " ++ symbol ++ " not found") in
+(* if b it is the first translation, else the second *)
+Fixpoint tsl_rec (fuel : nat) (Σ : global_context) (E : tsl_table) (Γ : context) (b : bool) (t : term) {struct fuel}
+  : tsl_result term :=
+  match fuel with
+  | O => raise NotEnoughFuel
+  | S fuel =>
   match t with
-  | tLambda na A t =>
-    let A0 := tsl_rec0 0 A in
-    let A1 := tsl_rec1_app None E A in
-    tLambda na A0 (tLambda (tsl_name tsl_ident na)
-                           (subst_app (lift0 1 A1) [tRel 0])
-                           (tsl_rec1_app (option_map (lift 2 2) app) E t))
-  | t => let t1 :=
+  | tRel n => ret (proj b (tRel n))
+  | tSort s => if b then ret (tSort s)
+              else ret (tLambda (nNamed "A") (tSort s) (tProd nAnon (tRel 0) (tSort s)))
+  | tCast t c A => if b then
+                    t1 <- tsl_rec fuel Σ E Γ true t ;;
+                    A1 <- tsl_rec fuel Σ E Γ true A ;;
+                    ret (tCast t1 c A1)
+                  else
+                    t1 <- tsl_rec fuel Σ E Γ true t ;;
+                    t2 <- tsl_rec fuel Σ E Γ false t ;;
+                    A2 <- tsl_rec fuel Σ E Γ false A ;;
+                    ret (tCast t2 c (tApp A2 [t1]))
+  | tProd n A B => if b then
+                    A' <- tsl_ty_param fuel Σ E Γ A ;;
+                    B1 <- tsl_rec fuel Σ E (Γ ,, vass n A) true B ;;
+                    ret (tProd n A' B1)
+                  else
+                    A' <- tsl_ty_param fuel Σ E Γ A ;;
+                    B1 <- tsl_rec fuel Σ E (Γ ,, vass n A) true B ;;
+                    B2 <- tsl_rec fuel Σ E (Γ ,, vass n A) false B ;;
+                    ret (tLambda (nNamed "f") (tProd n A' B1)
+                                 (tProd n (lift 1 0 A')
+                                        (tApp (lift 1 1 B2)
+                                              [tApp (tRel 1) [tRel 0]])))
+  | tLambda n A t => A' <- tsl_ty_param fuel Σ E Γ A ;;
+                    t' <- tsl_rec fuel Σ E (Γ ,, vass n A) b t ;;
+                    ret (tLambda n A' t')
+  | tLetIn n t A u => t' <- tsl_term fuel Σ E Γ t ;;
+                     A' <- tsl_ty_param fuel Σ E Γ A ;;
+                     u' <- tsl_rec fuel Σ E (Γ ,, vdef n t A) b u ;;
+                     ret (tLetIn n t' A' u')
+  | tApp t u => t' <- tsl_rec fuel Σ E Γ b t ;;
+               u' <- monad_map (tsl_term fuel Σ E Γ) u ;;
+               ret (tApp t' u')
+  | tConst _ _ as t
+  | tInd _ _ as t
+  | tConstruct _ _ _ as t => t' <- tsl_term fuel Σ E Γ t ;;
+                            ret (proj b t')
+  | _ => raise TranslationNotHandeled
+  end
+  end
+with tsl_term  (fuel : nat) (Σ : global_context) (E : tsl_table) (Γ : context) (t : term) {struct fuel}
+  : tsl_result term :=
+  match fuel with
+  | O => raise NotEnoughFuel
+  | S fuel =>
   match t with
-  | tRel k => tRel (2 * k)
-  | tSort s => tLambda (nNamed "A") (tSort s) (tProd nAnon (tRel 0) (tSort s))
-
-  | tProd na A B =>
-    let A0 := tsl_rec0 0 A in
-    let A1 := tsl_rec1 E A in
-    let B0 := tsl_rec0 1 B in
-    let B1 := tsl_rec1 E B in
-    let ΠAB0 := tProd na A0 B0 in
-    tLambda (nNamed "f") ΠAB0
-      (tProd na (lift0 1 A0)
-             (tProd (tsl_name tsl_ident na)
-                    (subst_app (lift0 2 A1) [tRel 0])
-                    (subst_app (lift 1 2 B1)
-                               [tApp (tRel 2) [tRel 1]])))
-  | tApp t us =>
-    let us' := concat (map (fun v => [tsl_rec0 0 v; tsl_rec1 E v]) us) in
-    mkApps (tsl_rec1 E t) us'
-
-  | tLetIn na t A u =>
-    let t0 := tsl_rec0 0 t in
-    let t1 := tsl_rec1 E t in
-    let A0 := tsl_rec0 0 A in
-    let A1 := tsl_rec1 E A in
-    let u0 := tsl_rec0 0 u in
-    let u1 := tsl_rec1 E u in
-    tLetIn na t0 A0 (tLetIn (tsl_name tsl_ident na) (lift0 1 t1)
-                            (subst_app (lift0 1 A1) [tRel 0]) u1)
-
-  | tCast t c A => let t0 := tsl_rec0 0 t in
-                  let t1 := tsl_rec1 E t in
-                  let A0 := tsl_rec0 0 A in
-                  let A1 := tsl_rec1 E A in
-                  tCast t1 c (mkApps A1 [tCast t0 c A0]) (* apply_subst ? *)
-
+  | tRel n => ret (tRel n)
+  | tCast t c A => t' <- tsl_term fuel Σ E Γ t ;;
+                  A' <- tsl_ty_param fuel Σ E Γ A ;;
+                  ret (tCast t' c A')
   | tConst s univs =>
     match lookup_tsl_table E (ConstRef s) with
-    | Some t => t
-    | None => debug "tConst" s
+    | Some t => ret t
+    | None => raise (TranslationNotFound s)
     end
   | tInd i univs =>
     match lookup_tsl_table E (IndRef i) with
-    | Some t => t
-    | None => debug "tInd" (match i with mkInd s _ => s end)
+    | Some t => ret t
+    | None => raise (TranslationNotFound (string_of_gref (IndRef i)))
     end
   | tConstruct i n univs =>
     match lookup_tsl_table E (ConstructRef i n) with
-    | Some t => t
-    | None => debug "tConstruct" (match i with mkInd s _ => s end)
+    | Some t => ret t
+    | None => raise (TranslationNotFound (string_of_gref (ConstructRef i n)))
     end
-  | tCase ik t u brs as case =>
-    let brs' := List.map (on_snd (lift0 1)) brs in
-    let case1 := tCase ik (lift0 1 t) (tRel 0) brs' in
-    match lookup_tsl_table E (IndRef (fst ik)) with
-    | Some (tInd i _univ) =>
-      tCase (i, (snd ik) * 2)
-            (tsl_rec1_app (Some (tsl_rec0 0 case1)) E t)
-            (tsl_rec1 E u)
-            (map (on_snd (tsl_rec1 E)) brs)
-    | _ => debug "tCase" (match (fst ik) with mkInd s _ => s end)
-    end
-  | _ => todo
-  end in
-  match app with Some t' => mkApp t1 (t' {3 := tRel 1} {2 := tRel 0})
-               | None => t1 end
-  end.
-Definition tsl_rec1 := tsl_rec1_app None.
+  | t => match infer Σ Γ t with
+         | Checked typ => let typ := refresh_universes typ in
+                          t1 <- tsl_rec fuel Σ E Γ true t ;;
+                        t2 <- tsl_rec fuel Σ E Γ false t ;;
+                        typ1 <- tsl_rec fuel Σ E Γ true typ ;;
+                        typ2 <- tsl_rec fuel Σ E Γ false typ ;;
+                        ret (pair typ1 typ2 t1 t2)
+        | TypeError t => raise (TypingError t)
+        end
+  end
+  end
+where "'tsl_ty_param'" := (fun fuel Σ E Γ t =>
+                        t1 <- tsl_rec fuel Σ E Γ true t ;;
+                        t2 <- tsl_rec fuel Σ E Γ false t ;;
+                        ret (pack t1 t2)).
 
-Definition tsl_mind_decl (E : tsl_table)
-           (kn kn' : kername) (mind : minductive_decl) : tsl_table * list minductive_decl.
-  refine (_, [{| ind_npars := 2 * mind.(ind_npars);
-                 ind_bodies := _;
-                 ind_universes := mind.(ind_universes)|}]).  (* FIXME always ok? *)
-  - refine (fold_left_i (fun E i ind => _ :: _ ++ E)%list mind.(ind_bodies) []).
-    + (* ind *)
-      exact (IndRef (mkInd kn i), tInd (mkInd kn' i) []).
-    + (* ctors *)
-      refine (fold_left_i (fun E k _ => _ :: E) ind.(ind_ctors) []).
-      exact (ConstructRef (mkInd kn i) k, tConstruct (mkInd kn' i) k []).
-  - refine (map_i _ mind.(ind_bodies)).
-    intros i ind.
-    refine {| ind_name := tsl_ident ind.(ind_name);
-              ind_type := _;
-              ind_kelim := ind.(ind_kelim);
-              ind_ctors := _;
-              ind_projs := [] |}. (* todo *)
-    + (* arity  *)
-      refine (let ar := subst_app (tsl_rec1 E ind.(ind_type))
-                                  [tInd (mkInd kn i) []] in
-              ar).
-    + (* constructors *)
-      refine (map_i _ ind.(ind_ctors)).
-      intros k ((name, typ), nargs).
-      refine (tsl_ident name, _, 2 * nargs).
-      refine (subst_app _ [tConstruct (mkInd kn i) k []]).
-      refine (fold_left_i (fun t0 i u  => t0 {S i := u}) _ (tsl_rec1 E typ)).
-      (* [I_n-1; ... I_0] *)
-      refine (rev (map_i (fun i _ => tInd (mkInd kn i) [])
-                              mind.(ind_bodies))).
+
+
+Instance tsl_param : Translation
+  := {| tsl_id := tsl_ident ;
+        tsl_tm := fun ΣE => tsl_term fuel (fst ΣE) (snd ΣE) [] ;
+        tsl_ty := fun ΣE => tsl_ty_param fuel (fst ΣE) (snd ΣE) [] ;
+        tsl_ind := todo |}.
+
+
+Definition TslParam := @tTranslate tsl_param.
+Definition ImplParam := @tImplement tsl_param.
+
+
+Notation "'TYPE'" := (exists A, A -> Type).
+Notation "'El' A" := (sigma (π1 A) (π2 A)) (at level 20).
+
+Definition Ty := Type.
+Set Printing Universes.
+Run TemplateProgram (TslParam emptyTC "Ty").
+Check Tyᵗ : El Tyᵗ.
+
+
+Definition mkTYPE (A₀ : Type) (Aᴿ : A₀ -> Type) : El Tyᵗ :=
+  @mk_sig Type (fun A₀ => A₀ -> Type) A₀ Aᴿ.
+
+Definition Prodᶠ (A : El Tyᵗ) (B : El A -> El Tyᵗ) : El Tyᵗ :=
+  mkTYPE
+    (forall x : El A, (B x).1)
+    (fun f₀ => forall x : El A, (B x).2 (f₀ x)).
+
+Notation "A →ᶠ B" := (Prodᶠ A (fun _ => B)) (at level 99, right associativity, B at level 200).
+Notation "'Πᶠ'  x .. y , P" := (Prodᶠ _ (fun x => .. (Prodᶠ _ (fun y => P)) ..))
+  (at level 200, x binder, y binder, right associativity).
+
+Definition Lamᶠ {A : El Tyᵗ} {B : El A -> El Tyᵗ} (f : forall x : El A, El (B x)) : El (Prodᶠ A B).
+Proof.
+unshelve refine (_ ; _).
++ refine (fun x => (f x).1).
++ refine (fun x => (f x).2).
 Defined.
 
+Notation "'λᶠ'  x .. y , t" := (Lamᶠ (fun x => .. (Lamᶠ (fun y => t)) ..))
+  (at level 200, x binder, y binder, right associativity).
 
-Run TemplateProgram (tm <- tmQuote (forall A, A -> A) ;;
-                     let tm' := tsl_rec1 [] tm in
-                     tmUnquote tm' >>= tmPrint).
-
-Run TemplateProgram (tm <- tmQuote (fun A (x : A) => x) ;;
-                     let tm' := tsl_rec1 [] tm in
-                     tmUnquote tm' >>= tmPrint).
-
-Goal ((fun f : forall A : Type, A -> A =>
-    forall (A : Type) (A0 : A -> Type) (H : A), A0 H -> A0 (f A H)) (fun A (x : A) => x)
-       = (forall (A : Type) (A0 : A -> Type) (x : A), A0 x -> A0 x)).
-reflexivity.
+Definition Appᶠ {A B} (f : El (Prodᶠ A B)) (x : El A) : El (B x).
+Proof.
+unshelve refine (_ ; _).
++ refine (f.1 x).
++ refine (f.2 x).
 Defined.
 
-
-Instance param : Translation :=
-  {| tsl_id := tsl_ident ;
-     tsl_tm := fun ΣE t => ret (tsl_rec1 (snd ΣE) t) ;
-     tsl_ty := fun '(Σ, E) t => todo "not meaningful here" ;
-     tsl_ind := fun ΣE kn kn' mind => ret (tsl_mind_decl (snd ΣE) kn kn' mind) |}.
+Notation "t · u" := (Appᶠ t u) (at level 65, left associativity).
 
 
-Definition T := forall A, A -> A.
-Run TemplateProgram (tTranslate emptyTC "T").
+Definition sigmaᵀ (A : El Tyᵗ) (P : El (A →ᶠ Tyᵗ)) : Type :=
+  sigma (El A) (fun x => El (P · x)).
+
+Definition existᵀ (A : El Tyᵗ) (P : El (A →ᶠ Tyᵗ))
+           (x : El A) (y : El (P · x)) : sigmaᵀ A P
+  := mk_sig x y.
+
+Inductive sigmaᴿ (A : El Tyᵗ) (P : El (A →ᶠ Tyᵗ)) : sigmaᵀ A P -> Type :=
+| existᴿ : forall (x : El A) (y : El (P · x)), sigmaᴿ A P (existᵀ A P x y).
+
+Definition sigmaᶠ : El (Πᶠ (A : El Tyᵗ) (P : El (A →ᶠ Tyᵗ)), Tyᵗ).
+Proof.
+refine (λᶠ A P, _).
+unshelve refine (mkTYPE _ (sigmaᴿ A P)).
+Defined.
+
+Definition existᶠ : El (Πᶠ (A : El Tyᵗ) (P : El (A →ᶠ Tyᵗ)) (x : El A) (y : El (P · x)),
+  sigmaᶠ · A · P).
+Proof.
+refine (λᶠ A P x y, _).
+refine (mk_sig (existᵀ A P x y) (existᴿ A P x y)).
+Defined.
+
+Inductive eq@{i} {A : Type@{i}} (x : A) : A -> Type@{i} :=  eq_refl : eq x x.
+
+Inductive eq2 (A : El Tyᵗ) (x : El A) :
+  forall (y : El A), eq (π1 x) (π1 y) -> Prop :=
+| refl2 : eq2 A x x (eq_refl _).
 
 
-Definition tm := ((fun A (x:A) => x) (Type -> Type) (fun x => x)).
-Run TemplateProgram (tTranslate emptyTC "tm").
+Definition eqᶠ : El (Πᶠ (A : El Tyᵗ), A →ᶠ A →ᶠ Tyᵗ).
+Proof.
+refine (λᶠ A x y, _).
+unshelve refine (mkTYPE _ _).
++ refine (eq x.1 y.1).
++ refine (eq2 A x y).
+Defined.
 
-Run TemplateProgram (TC <- tTranslate emptyTC "nat" ;;
-                     tmDefinition "nat_TC" TC ).
+Definition reflᶠ : El (Πᶠ (A : El Tyᵗ) (x : El A), eqᶠ · A · x · x).
+Proof.
+refine (λᶠ A x, _).
+unshelve refine (_; refl2 A x).
+Defined.
 
-Run TemplateProgram (tTranslate nat_TC "pred").
+Definition Falseᶠ : El Tyᵗ.
+  exists False. exact (fun _ => False).
+Defined.
+  
 
-
-Module Id1.
-  Definition ID := forall A, A -> A.
-
-  Run TemplateProgram (tTranslate emptyTC "ID").
-
-  Lemma param_ID_identity (f : ID)
-    : IDᵗ f -> forall A x, f A x = x.
-  Proof.
-    compute. intros H A x.
-    exact (H A (fun y => y = x) x (eq_refl x)).
-  Qed.
-
-  Definition toto := fun n : nat => (fun y => 0) (fun _ : Type =>  n).
-  Run TemplateProgram (tTranslate nat_TC "toto").
-
-
-  Definition my_id : ID :=
-    let n := 12 in (fun (_ : nat) y => y) 4 (fun A x => (fun _ : nat => x) n).
-
-  Run TemplateProgram (tTranslate nat_TC "my_id").
-
-
-  Definition free_thm_my_id : forall A x, my_id A x = x
-    := param_ID_identity my_id my_idᵗ.
-End Id1.
+Quote Recursively Definition sigma_prog := @sigma.
+Quote Recursively Definition eq_prog := @eq.
+Quote Recursively Definition false_prog := @False.
+Definition sigma_decl := Eval compute in
+      extract_mind_decl_from_program "Translations.sigma.sigma" sigma_prog.
+Definition eq_decl := Eval compute in
+      extract_mind_decl_from_program "Translations.tsl_param.eq" eq_prog.
+Definition false_decl := Eval compute in
+      extract_mind_decl_from_program "Coq.Init.Logic.False" false_prog.
 
 
-Module Id2.
-  Definition ID := forall A x y (p : x = y :> A), x = y.
+Definition ΣE : option tsl_context :=
+  sd <- sigma_decl ;;
+  ed <- eq_decl ;;
+  fd <- false_decl ;;
+  let Σ' := add_global_decl (InductiveDecl "Coq.Init.Logic.False" fd) (
+            add_global_decl (InductiveDecl "Translations.tsl_param.eq" ed) (
+            add_global_decl (InductiveDecl "Translations.sigma.sigma" sd)
+            ([], init_graph))) in
+  let E' := [(IndRef (mkInd "Translations.sigma.sigma" 0),
+              tConst "sigmaᶠ" []);
+             (ConstructRef (mkInd "Translations.sigma.sigma" 0) 0,
+              tConst "existᶠ" []);
+             (IndRef (mkInd "Translations.tsl_param.eq" 0), tConst "eqᶠ" []);
+             (IndRef (mkInd "Coq.Init.Logic.False" 0), tConst "Falseᶠ" [])
+            ] in
+  ret (Σ', E').
 
-  Run TemplateProgram (TC <- tTranslate emptyTC "eq" ;;
-                       TC <- tTranslate TC "ID" ;;
-                       tmDefinition "TC" TC).
-
-
-  Lemma param_ID_identity (f : ID)
-    : IDᵗ f -> forall A x y p, f A x y p = p.
-  Proof.
-    compute. intros H A x y p.
-    destruct p.
-    specialize (H A (fun y => x = y) x eq_refl x eq_refl eq_refl
-                  (eq_reflᵗ _ _ _ _)).
-    destruct H. reflexivity.
-  Qed.
-
-  Definition myf : ID
-    := fun A x y p => eq_trans (eq_trans p (eq_sym p)) p.
-
-  Run TemplateProgram (TC <- tTranslate TC "eq_sym" ;;
-                       TC <- tTranslate TC "eq_trans" ;;
-                       tTranslate TC "myf").
-
-  Definition free_thm_myf : forall A x y p, myf A x y p = p
-    := param_ID_identity myf myfᵗ.
-End Id2.
+Definition HasTwoElFstComponentᵗ : El (Tyᵗ →ᶠ Tyᵗ)
+  := λᶠ (T : El Tyᵗ), mkTYPE (exists (x y : T.1), x = y -> False) (fun _ => unit).
 
 
+Definition equiv (A B : Type) :=
+  (* Type. *)
+  exists (f : A -> B) (g : B -> A),
+    (forall x, eq (g (f x)) x) × (forall x, eq (f (g x)) x).
+
+Definition FALSE := forall X, X.
+Run TemplateProgram (TslParam emptyTC "FALSE").
+
+Proposition consistency_preservation : El FALSEᵗ -> FALSE.
+  compute.
+  intros [f _] X.
+  exact (f (X; fun _ => unit)).
+Defined.
+
+Quote Definition equiv_ := Eval compute in equiv.
 
 
+(* Check "go". *)
 
-Module Vectors.
-  Import Vector.
-  Run TemplateProgram (tTranslate nat_TC "t").
-End Vectors.
-
-Require Import Even.
-Run TemplateProgram (tTranslate nat_TC "even").
-
-Definition rev_type := forall A, list A -> list A.
-Run TemplateProgram (TC <- tTranslate emptyTC "list" ;;
-                     TC <- tTranslate TC "rev_type" ;;
-                     tmDefinition "list_TC" TC ).
-
-
-
-(* Definition isequiv (A B : Type) (f : A -> B) := *)
-(*   exists (g : B -> A), (forall x, g (f x) = x) × (forall y, f (g y) = y). *)
-
-(* Definition equiv_id A : isequiv A A (fun x => x). *)
-(*   unshelve econstructor. exact (fun y => y). *)
-(*   split; reflexivity. *)
+(* Run TemplateProgram (match ΣE with *)
+(*                      | None => tmFail "bug: no tsl_ctx" *)
+(*                      | Some ΣE => *)
+(*                        ΣE <- TslParam ΣE "equiv" ;; *)
+(*                        (* tmPrint ΣE' ;; *) *)
+(*                        tmPrint "lo" ;; *)
+(*                        H <- ImplParam ΣE "notUnivalence" *)
+(*                        (exists A B : Type, (equiv A B) × exists P, P A × ((P B) -> False)) ;; *)
+(*                        (* (exists A : Type, (equiv A A)) ;; *) *)
+(*                        tmPrint "done" *)
+(*                      end). *)
+(* Check "proof". *)
+(* Next Obligation. *)
+(* simple refine (existᶠ · _ · _ · _ · _). *)
+(* exact (bool:Type; fun _=> unit:Type). *)
+(* simple refine (existᶠ · _ · _ · _ · _). *)
+(* exact (unit:Type; fun _ => bool:Type). *)
+(* simple refine (existᶠ · _ · _ · _ · _). *)
+(* - simple refine (existᶠ · _ · _ · _ · _). *)
+(*   exists π2. exact π1. *)
+(*   simple refine (existᶠ · _ · _ · _ · _). *)
+(*   exists π2. exact π1. *)
+(*   simple refine (existᶠ · _ · _ · _ · _); *)
+(*     cbn; unshelve econstructor; reflexivity. *)
+(* - simple refine (existᶠ · _ · _ · _ · _). *)
+(*   exact HasTwoElFstComponentᵗ. *)
+(*   simple refine (existᶠ · _ · _ · _ · _). *)
+(*   + cbn. refine (_; tt). exists true. exists false. *)
+(*     discriminate 1. *)
+(*   + compute. *)
+(*     split; (intro p; *)
+(*             destruct p as [p _]; *)
+(*             destruct p as [[] [[] p]]; *)
+(*             contradiction p; reflexivity). *)
 (* Defined. *)
 
-(* Run TemplateProgram (TC <- tTranslate [] "sigma" ;; *)
-(*                      TC <- tTranslate TC "eq" ;; *)
-(*                      TC <- tTranslate TC "isequiv" ;; *)
-(*                      TC <- tTranslate TC "equiv_id" ;; *)
-(*                      tmDefinition "TC" TC). *)
-
-(* Quote Definition eq_rect_Type_ := (forall (A : Type) (x : A) (P : A -> Type), *)
-(* P x -> forall y : A, x = y -> P y). *)
-(* Make Definition eq_rect_Typeᵗ :=  ltac:(let t:= eval compute in (tsl_rec1 TC eq_rect_Type_) in exact t). *)
-
-(* Lemma eq_rectᵗ : eq_rect_Typeᵗ eq_rect. *)
-(*   compute. intros A Aᵗ x xᵗ P Pᵗ X X0 y yᵗ H H0.  *)
-(*     by destruct H0. *)
-(* Defined. *)
-
-(* Definition TC' := (ConstRef "Coq.Init.Logic.eq_rect", tConst "eq_rectᵗ" []) :: TC. *)
-
-(* Definition eq_to_iso A B : A = B -> exists f, isequiv A B f. *)
-(*   refine (eq_rect _ (fun B => exists f : A -> B, isequiv A B f) _ _). *)
-(*   econstructor. *)
-(*   eapply equiv_id. *)
-(* Defined. *)
-
-(* Definition UA := forall A B, isequiv _ _ (eq_to_iso A B). *)
-
-(* Run TemplateProgram (TC <- tTranslate TC' "eq_to_iso" ;; *)
-(*                      tTranslate TC "UA"). *)
-
-(* Arguments isequiv {A B} _. *)
-(* Arguments isequivᵗ {_ _ _ _} _ _. *)
-(* Arguments eqᵗ {A Aᵗ x xᵗ H} _ _.  *)
-
-(* Axiom ua : UA. *)
-
-(* Goal UAᵗ ua. *)
-(*   intros A Aᵗ B Bᵗ.  *)
-(*   unshelve econstructor. *)
-(*   - intros [f e] []. clear f e. *)
-(*     assert (forall H, isequiv (π1ᵗ H)). { *)
-(*       destruct π2ᵗ. destruct π2ᵗ. *)
-(*       intro x. unshelve econstructor. *)
-(*       by refine (fun y => eq_rect _ Aᵗ (π1ᵗ0 _ y) _ _). *)
-(*       split. { intro. *)
+(* Check "ok!". *)


### PR DESCRIPTION
This is a step towards functorizing the monad, so that monadic programs can be run after extraction.
Sorry, this took long and may be too late for the deadline.
This PR is incomplete: some functions (mentioned below) are defined as `failwith "not yet implemented"`.
I can fix them and then work on functorizing the monad. However, most likely, I wont be able to finish that before the deadline. Thus I am sharing this incomplete work in case someone wants to go ahead and finish it.
The following functions are defined as `failwith "not yet implemented"` in reify.ml4:
1) `unquote_kn`
2) `unquote_proj`
I couldn't figure out how to implement them: perhaps I need to search the Coq codebase harder.
Also, template_coq4.ml has many functions defined as `failwith "not yet implemented"`. Implementing them should be easy.

Any feedback is welcome. As I mentioned, this is incomplete work. I can finish it, but perhaps not before the deadline.
