### PR TITLE
Rename Constraint to ConstraintSet

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -349,9 +349,9 @@ struct
   let cMonomorphic_ctx = resolve_symbol pkg_univ "Monomorphic_ctx"
   let cPolymorphic_ctx = resolve_symbol pkg_univ "Polymorphic_ctx"
   let tUContextmake = resolve_symbol (ext_pkg_univ "UContext") "make"
-  (* let tConstraintempty = resolve_symbol (ext_pkg_univ "Constraint") "empty" *)
-  let tConstraintempty = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "Constraint") "empty")
-  let tConstraintadd = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "Constraint") "add")
+  (* let tConstraintSetempty = resolve_symbol (ext_pkg_univ "ConstraintSet") "empty" *)
+  let tConstraintSetempty = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "empty")
+  let tConstraintSetadd = Universes.constr_of_global (Coqlib.find_reference "template coq bug" (ext_pkg_univ "ConstraintSet") "add")
   let tmake_univ_constraint = resolve_symbol pkg_univ "make_univ_constraint"
   let tinit_graph = resolve_symbol pkg_ugraph "init_graph"
   let tadd_global_constraints = resolve_symbol pkg_ugraph  "add_global_constraints"
@@ -513,8 +513,8 @@ struct
     let const = Univ.Constraint.elements const in
     List.fold_left (fun tm c ->
         let c = quote_univ_constraint c in
-        Term.mkApp (tConstraintadd, [| c; tm|])
-      ) tConstraintempty const
+        Term.mkApp (tConstraintSetadd, [| c; tm|])
+      ) tConstraintSetempty const
 
   let quote_ucontext inst const =
     let inst' = quote_univ_instance inst in

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -135,7 +135,7 @@ Definition mut_i : mutual_inductive_entry :=
   mind_entry_finite := Finite;
   mind_entry_params := [];
   mind_entry_inds := [one_i; one_i2];
-  mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
+  mind_entry_universes := Monomorphic_ctx ([], ConstraintSet.empty);
   mind_entry_private := None;
 |}.
 
@@ -162,7 +162,7 @@ Definition mut_list_i : mutual_inductive_entry :=
   mind_entry_finite := Finite;
   mind_entry_params := [("A", LocalAssum (tSort Universe.type0))];
   mind_entry_inds := [one_list_i];
-  mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
+  mind_entry_universes := Monomorphic_ctx ([], ConstraintSet.empty);
   mind_entry_private := None;
 |}.
 
@@ -187,7 +187,7 @@ Definition mut_pt_i : mutual_inductive_entry :=
   mind_entry_finite := BiFinite;
   mind_entry_params := [("A", LocalAssum (tSort Universe.type0))];
   mind_entry_inds := [one_pt_i];
-  mind_entry_universes := Monomorphic_ctx ([], Constraint.empty);
+  mind_entry_universes := Monomorphic_ctx ([], ConstraintSet.empty);
   mind_entry_private := None;
 |}.
 

--- a/test-suite/univ.v
+++ b/test-suite/univ.v
@@ -61,8 +61,8 @@ Module toto.
   (*               tProd nAnon (tSort ((Level.Var 0, false) :: nil)%list) (tRel 1), *)
   (*               1) :: nil; *)
   (*  ind_projs := nil |}] (UContext.make (Level.Var 0 :: Level.Var 1 :: nil)%list *)
-  (*    (Constraint.add (make_univ_constraint (Level.Var 0) Lt (Level.Var 1)) *)
-  (*       Constraint.empty)))) ;; *)
+  (*    (ConstraintSet.add (make_univ_constraint (Level.Var 0) Lt (Level.Var 1)) *)
+  (*       ConstraintSet.empty)))) ;; *)
 
 End toto.
 

--- a/theories/Checker.v
+++ b/theories/Checker.v
@@ -378,7 +378,7 @@ Inductive type_error :=
 | NotAProduct (t t' : term)
 | NotAnInductive (t : term)
 | IllFormedFix (m : mfixpoint term) (i : nat)
-| UnsatisfiedConstraints (c : Constraint.t)
+| UnsatisfiedConstraints (c : ConstraintSet.t)
 | NotEnoughFuel (n : nat).
 
 Definition string_of_nat (n : nat) := Template.utils.string_of_int n.
@@ -595,7 +595,7 @@ Section Typecheck2.
 
   Definition polymorphic_constraints (u : universe_context) :=
     match u with
-    | Monomorphic_ctx _ => Constraint.empty
+    | Monomorphic_ctx _ => ConstraintSet.empty
     | Polymorphic_ctx ctx => UContext.constraints ctx
     end.
 

--- a/theories/Typing.v
+++ b/theories/Typing.v
@@ -638,7 +638,7 @@ Definition type_global_decl Σ decl :=
 
 Definition contains_init_graph φ :=
   LevelSet.In Level.prop (fst φ) /\ LevelSet.In Level.set (fst φ) /\
-  Constraint.In (Level.prop, ConstraintType.Le, Level.set) (snd φ).
+  ConstraintSet.In (Level.prop, ConstraintType.Le, Level.set) (snd φ).
 
 Definition wf_graph φ :=
   contains_init_graph φ /\ (no_universe_inconsistency φ = true).

--- a/theories/UnivSubst.v
+++ b/theories/UnivSubst.v
@@ -21,9 +21,9 @@ Definition subst_instance_level u l :=
   end.
 
 Definition subst_instance_cstrs u cstrs :=
-  Constraint.fold (fun '(l,d,r) =>
-                     Constraint.add (subst_instance_level u l, d, subst_instance_level u r))
-                  cstrs Constraint.empty.
+  ConstraintSet.fold (fun '(l,d,r) =>
+                     ConstraintSet.add (subst_instance_level u l, d, subst_instance_level u r))
+                  cstrs ConstraintSet.empty.
 
 Definition subst_instance_level_expr (u : universe_instance) (s : Universe.Expr.t) :=
   let '(l, b) := s in (subst_instance_level u l, b).

--- a/theories/kernel/univ.v
+++ b/theories/kernel/univ.v
@@ -305,14 +305,14 @@ Module UnivConstraintDec.
     unfold eq. repeat decide equality.
   Defined.
 End UnivConstraintDec.
-Module Constraint := MSets.MSetWeakList.Make UnivConstraintDec.
+Module ConstraintSet := MSets.MSetWeakList.Make UnivConstraintDec.
 
 Definition make_univ_constraint : universe_level -> constraint_type -> universe_level -> univ_constraint
   := fun x y z => (x, y, z).
 
 (** Needs to be in Type because template polymorphism of MSets does not allow setting
     the lowest universe *)
-Definition constraints : Type := Constraint.t.  (* list univ_constraint *)
+Definition constraints : Type := ConstraintSet.t.  (* list univ_constraint *)
 
 (* val empty_constraint : constraints *)
 (* val union_constraint : constraints -> constraints -> constraints *)
@@ -397,15 +397,15 @@ Module UContext.
   Definition t := constrained Instance.t.
 
   (* Definition make : constrained Instance.t -> t := fun x => x. *)
-  Definition make : Instance.t -> Constraint.t -> t := pair.
+  Definition make : Instance.t -> ConstraintSet.t -> t := pair.
 
-  Definition empty : t := (Instance.empty, Constraint.empty).
+  Definition empty : t := (Instance.empty, ConstraintSet.empty).
   (* val is_empty : t -> bool *)
 
   Definition instance : t -> Instance.t := fst.
   Definition constraints : t -> constraints := snd.
 
-  Definition dest : t -> Instance.t * Constraint.t := fun x => x.
+  Definition dest : t -> Instance.t * ConstraintSet.t := fun x => x.
 
   (* (** Keeps the order of the instances *) *)
   (* val union : t -> t -> t *)


### PR DESCRIPTION
I am hesitating in renaming the module `Constraint` to `ConstraintSet` in kernel/univ.v.
Pros:
- It is more meaningful (Constrain.t is a set of constraints)
- And more uniform (set of levels are named LevelSet.t)

Cons:
- I does not follow the naming of the Coq source code ...

Any opinion?