### PR TITLE
Error message for ill-typed terms in tmUnquote

### DIFF
--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -671,7 +671,7 @@ let rec run_template_program_rec (k : Evd.evar_map * Constr.t -> unit)  ((evm, p
   else if Constr.equal coConstr tmUnquote then
     match args with
     | t::[] ->
-       try
+       (try
          let (evm, t) = reduce_all env evm t in
          let evdref = ref evm in
          let t' = denote_term evdref t in

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -671,17 +671,19 @@ let rec run_template_program_rec (k : Evd.evar_map * Constr.t -> unit)  ((evm, p
   else if Constr.equal coConstr tmUnquote then
     match args with
     | t::[] ->
-       let (evm, t) = reduce_all env evm t in
-       let evdref = ref evm in
-       let t' = denote_term evdref t in
-       let evm = !evdref in
-       let typ = EConstr.to_constr evm (Retyping.get_type_of env evm (EConstr.of_constr t')) in
-       (* todo: we could declare a new universe <= Coq.Init.Specif.7 or 8 instead of using [texistT_typed_term] *)
-       (* let (evm, u) = Evd.fresh_sort_in_family env evm Sorts.InType in *)
-       (* (env, evm, Constr.mkApp (texistT, [|Constr.mkSort u; *)
-       (*                                   Constr.mkLambda (Names.Name (Names.Id.of_string "T"), Constr.mkSort u, Constr.mkRel 1); *)
-       (*                                   typ; t'|])) *)
-       k (evm, Constr.mkApp (texistT_typed_term, [|typ; t'|]))
+       try
+         let (evm, t) = reduce_all env evm t in
+         let evdref = ref evm in
+         let t' = denote_term evdref t in
+         let evm = !evdref in
+         let typ = EConstr.to_constr evm (Retyping.get_type_of env evm (EConstr.of_constr t')) in
+         (* todo: we could declare a new universe <= Coq.Init.Specif.7 or 8 instead of using [texistT_typed_term] *)
+         (* let (evm, u) = Evd.fresh_sort_in_family env evm Sorts.InType in *)
+         (* (env, evm, Constr.mkApp (texistT, [|Constr.mkSort u; *)
+         (*                                   Constr.mkLambda (Names.Name (Names.Id.of_string "T"), Constr.mkSort u, Constr.mkRel 1); *)
+         (*                                   typ; t'|])) *)
+         k (evm, Constr.mkApp (texistT_typed_term, [|typ; t'|]))
+       with Reduction.NotArity -> CErrors.user_err (str "unquoting ill-typed term"))
     | _ -> monad_failure "tmUnquote" 1
   else if Constr.equal coConstr tmUnquoteTyped then
     match args with

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -253,7 +253,7 @@ Definition program : Type := global_declarations * term.
 (** Reduction strategy to apply, beware [cbv], [cbn] and [lazy] are _strong_. *)
 
 Inductive reductionStrategy : Set :=
-  cbv | cbn | hnf | all | lazy.
+  cbv | cbn | hnf | all | lazy | unfold (i : ident).
 
 Definition typed_term := {T : Type & T}.
 Definition existT_typed_term a t : typed_term := @existT Type (fun T => T) a t.


### PR DESCRIPTION
At the moment, tmUnquote raises a "Reduction.NotArity" anomaly #28. This is a proper error now.