### PR TITLE
Add unfold to reductionStrategy to tmEval

### DIFF
--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -149,7 +149,7 @@ struct
   let cParameter_entry = r_reify "Build_parameter_entry"
   let cDefinition_entry = r_reify "Build_definition_entry"
 
-  let (tcbv, tcbn, thnf, tall, tlazy) = (r_reify "cbv", r_reify "cbn", r_reify "hnf", r_reify "all", r_reify "lazy")
+  let (tcbv, tcbn, thnf, tall, tlazy, tunfold) = (r_reify "cbv", r_reify "cbn", r_reify "hnf", r_reify "all", r_reify "lazy", r_reify "unfold")
 
   let (tglobal_reference, tConstRef, tIndRef, tConstructRef) = (r_reify "global_reference", r_reify "ConstRef", r_reify "IndRef", r_reify "ConstructRef")
 

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -382,8 +382,6 @@ let denote_term evdref (trm: Constr.t) : Constr.t =
     | _ ->  not_supported_verb trm "big_case"
   in aux trm
 
-let constant str = Universes.constr_of_global (Smartlocate.locate_global_with_alias (None, Libnames.qualid_of_string str)) 
-
 let denote_reduction_strategy evm (trm : quoted_reduction_strategy) : Redexpr.red_expr =
   let env = Global.env () in
   let (evm, pgm) = reduce_hnf env evm trm in
@@ -398,7 +396,7 @@ let denote_reduction_strategy evm (trm : quoted_reduction_strategy) : Redexpr.re
   else if Term.eq_constr trm tunfold then (match args with name (* to unfold *) :: _ ->
                                                             let (evm, name) = reduce_all env evm name in
                                                             let name = unquote_ident name in
-                                                            (try Unfold [AllOccurrences, EvalConstRef (fst (EConstr.destConst evm (EConstr.of_constr (constant (Names.Id.to_string name))))) ]
+                                                            (try Unfold [AllOccurrences, Tacred.evaluable_of_global_reference env (Nametab.global (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident name))))]
                                                              with
                                                                _ -> CErrors.user_err (str "Constant not found or not a constant: " ++ Pp.str (Names.Id.to_string name)))
                                                          | _ -> raise  (Failure "ill-typed reduction strategy"))

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -253,7 +253,7 @@ Definition program : Type := global_declarations * term.
 (** Reduction strategy to apply, beware [cbv], [cbn] and [lazy] are _strong_. *)
 
 Inductive reductionStrategy : Set :=
-  cbv | cbn | hnf | all | lazy.
+  cbv | cbn | hnf | all | lazy | unfold (i : ident).
 
 Definition typed_term := {T : Type & T}.
 Definition existT_typed_term a t : typed_term := @existT Type (fun T => T) a t.

--- a/test-suite/unfold.v
+++ b/test-suite/unfold.v
@@ -1,0 +1,3 @@
+Require Import Template.All.
+
+Run TemplateProgram (tmBind (tmEval (unfold "negb") negb) tmPrint).


### PR DESCRIPTION
I sometimes need to unfold single definitions in a term. Since that can't be replayed with the current strategies, I added `unfold (s : string)` to the `reductionStrategy` type.

That hopefully shouldn't break anything (but I'm not sure this is the best way to unfold definitions)