### PR TITLE
Optional reduction argument for tmDefinition

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1567,6 +1567,19 @@ struct
       else bad_term trm
       | _ -> bad_term trm
 
+  let denote_option trm =
+    let (h,args) = app_full trm [] in
+    if Term.eq_constr h cSome then
+    match args with
+	  _ :: x :: _ -> Some (x)
+      | _ -> bad_term trm
+    else if Term.eq_constr h cNone then
+    match args with
+	  _ :: [] -> None
+      | _ -> bad_term trm
+    else
+      not_supported_verb trm "unqote_map_option"
+           
   let unquote_map_option f trm =
     let (h,args) = app_full trm [] in
     if Term.eq_constr h cSome then
@@ -1678,13 +1691,13 @@ struct
       | _ -> monad_failure_full "tmBind" 4 pgm
     else if Term.eq_constr coConstr tmDefinition then
       match args with
-      | name::typ::body::[] ->
+      | name::s::typ::body::[] ->
          let (evm, name) = reduce_all env evm name in
          (* todo: let the user choose the reduction used for the type *)
-         let (evm, typ) = reduce_hnf env evm typ in
+         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy evm s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let n = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) ~types:typ (body, Evd.universe_context_set evm) in
          k (evm, Term.mkConst n)
-      | _ -> monad_failure "tmDefinition" 3
+      | _ -> monad_failure "tmDefinition" 4
     else if Term.eq_constr coConstr tmAxiom then
       match args with
       | name::typ::[] ->
@@ -1696,9 +1709,9 @@ struct
       | _ -> monad_failure "tmAxiom" 2
     else if Term.eq_constr coConstr tmLemma then
       match args with
-      | name::typ::[] ->
+      | name::s::typ::[] ->
          let (evm, name) = reduce_all env evm name in
-         let (evm, typ) = reduce_hnf env evm typ in
+         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy evm s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let kind = (Decl_kinds.Global, Flags.use_polymorphic_flag (), Decl_kinds.Definition) in
          let hole = CAst.make (Constrexpr.CHole (None, Misctypes.IntroAnonymous, None)) in
          let typ = Constrextern.extern_type true env evm (EConstr.of_constr typ) in

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1694,7 +1694,7 @@ struct
       | name::s::typ::body::[] ->
          let (evm, name) = reduce_all env evm name in
          (* todo: let the user choose the reduction used for the type *)
-         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy evm s in reduce_all ~red env evm typ | None -> (evm, typ)) in
+         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let n = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) ~types:typ (body, Evd.universe_context_set evm) in
          k (evm, Term.mkConst n)
       | _ -> monad_failure "tmDefinition" 4
@@ -1711,7 +1711,7 @@ struct
       match args with
       | name::s::typ::[] ->
          let (evm, name) = reduce_all env evm name in
-         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy evm s in reduce_all ~red env evm typ | None -> (evm, typ)) in
+         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let kind = (Decl_kinds.Global, Flags.use_polymorphic_flag (), Decl_kinds.Definition) in
          let hole = CAst.make (Constrexpr.CHole (None, Misctypes.IntroAnonymous, None)) in
          let typ = Constrextern.extern_type true env evm (EConstr.of_constr typ) in

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -383,10 +383,10 @@ struct
 
   let (tglobal_reference, tConstRef, tIndRef, tConstructRef) = (r_reify "global_reference", r_reify "ConstRef", r_reify "IndRef", r_reify "ConstructRef")
 
-  let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinition, tmAxiom, tmLemma, tmFreshName, tmAbout, tmCurrentModPath,
+  let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinitionRed, tmAxiomRed, tmLemmaRed, tmFreshName, tmAbout, tmCurrentModPath,
        tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped) =
-    (r_reify "tmReturn", r_reify "tmBind", r_reify "tmQuote", r_reify "tmQuoteRec", r_reify "tmEval", r_reify "tmDefinition",
-     r_reify "tmAxiom", r_reify "tmLemma", r_reify "tmFreshName", r_reify "tmAbout", r_reify "tmCurrentModPath",
+    (r_reify "tmReturn", r_reify "tmBind", r_reify "tmQuote", r_reify "tmQuoteRec", r_reify "tmEval", r_reify "tmDefinitionRed",
+     r_reify "tmAxiomRed", r_reify "tmLemmaRed", r_reify "tmFreshName", r_reify "tmAbout", r_reify "tmCurrentModPath",
      r_reify "tmMkDefinition", r_reify "tmMkInductive", r_reify "tmPrint", r_reify "tmFail", r_reify "tmQuoteInductive", r_reify "tmQuoteConstant",
      r_reify "tmQuoteUniverses", r_reify "tmUnquote", r_reify "tmUnquoteTyped")
 
@@ -1689,7 +1689,7 @@ struct
       | _::_::a::f::[] ->
          run_template_program_rec (fun (evm, ar) -> run_template_program_rec k (evm, Term.mkApp (f, [|ar|]))) (evm, a)
       | _ -> monad_failure_full "tmBind" 4 pgm
-    else if Term.eq_constr coConstr tmDefinition then
+    else if Term.eq_constr coConstr tmDefinitionRed then
       match args with
       | name::s::typ::body::[] ->
          let (evm, name) = reduce_all env evm name in
@@ -1697,17 +1697,17 @@ struct
          let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let n = Declare.declare_definition ~kind:Decl_kinds.Definition (unquote_ident name) ~types:typ (body, Evd.universe_context_set evm) in
          k (evm, Term.mkConst n)
-      | _ -> monad_failure "tmDefinition" 4
-    else if Term.eq_constr coConstr tmAxiom then
+      | _ -> monad_failure "tmDefinitionRed" 4
+    else if Term.eq_constr coConstr tmAxiomRed then
       match args with
-      | name::typ::[] ->
+      | name::s::typ::[] ->
          let (evm, name) = reduce_all env evm name in
-         let (evm, typ) = reduce_hnf env evm typ in
+         let (evm, typ) = (match denote_option s with Some s -> let red = denote_reduction_strategy s in reduce_all ~red env evm typ | None -> (evm, typ)) in
          let param = Entries.ParameterEntry (None, false, (typ, UState.context (Evd.evar_universe_context evm)), None) in
          let n = Declare.declare_constant (unquote_ident name) (param, Decl_kinds.IsDefinition Decl_kinds.Definition) in
          k (evm, Term.mkConst n)
-      | _ -> monad_failure "tmAxiom" 2
-    else if Term.eq_constr coConstr tmLemma then
+      | _ -> monad_failure "tmAxiomRed" 3
+    else if Term.eq_constr coConstr tmLemmaRed then
       match args with
       | name::s::typ::[] ->
          let (evm, name) = reduce_all env evm name in
@@ -1727,7 +1727,7 @@ struct
                                  (* let evm, t = Evd.fresh_global env evm gr in k (env, evm, t) *)
                                  (* k (env, evm, unit_tt) *)
                             (* )); *)
-      | _ -> monad_failure "tmLemma" 2
+      | _ -> monad_failure "tmLemmaRed" 2
     else if Term.eq_constr coConstr tmMkDefinition then
       match args with
       | name::body::[] ->

--- a/test-suite/demo.v
+++ b/test-suite/demo.v
@@ -258,9 +258,11 @@ Run TemplateProgram (tmDefinition "foo4'" nat >>= tmPrint).
 (* We can chain the definition. In the following,
  foo5' = 12 and foo6' = foo5' *)
 Run TemplateProgram (t <- tmDefinition "foo5'" 12 ;;
-                     tmDefinition "foo6'" t).
+                       tmDefinition "foo6'" t).
 
-Run TemplateProgram (tmLemma "foo51" nat ;;
+Obligation Tactic := idtac.
+
+Run TemplateProgram (tmLemma "foo51" nat;;
                      tmLemma "foo61" bool).
 Next Obligation.
   exact 3.
@@ -268,7 +270,6 @@ Defined.
 Next Obligation.
   exact true.
 Qed.
-
 
 
 

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -283,9 +283,9 @@ Inductive TemplateMonad : Type -> Type :=
 | tmEval : reductionStrategy -> forall {A:Type}, A -> TemplateMonad A
 
 (* Return the defined constant *)
-| tmDefinition : ident -> forall {A:Type}, A -> TemplateMonad A
+| tmDefinition : ident -> option reductionStrategy -> forall {A:Type}, A -> TemplateMonad A
 | tmAxiom : ident -> forall A, TemplateMonad A
-| tmLemma : ident -> forall A, TemplateMonad A
+| tmLemma : ident -> option reductionStrategy -> forall A, TemplateMonad A
 
 (* Guarenteed to not cause "... already declared" error *)
 | tmFreshName : ident -> TemplateMonad ident

--- a/theories/Ast.v
+++ b/theories/Ast.v
@@ -283,9 +283,9 @@ Inductive TemplateMonad : Type -> Type :=
 | tmEval : reductionStrategy -> forall {A:Type}, A -> TemplateMonad A
 
 (* Return the defined constant *)
-| tmDefinition : ident -> option reductionStrategy -> forall {A:Type}, A -> TemplateMonad A
-| tmAxiom : ident -> forall A, TemplateMonad A
-| tmLemma : ident -> option reductionStrategy -> forall A, TemplateMonad A
+| tmDefinitionRed : ident -> option reductionStrategy -> forall {A:Type}, A -> TemplateMonad A
+| tmAxiomRed : ident -> option reductionStrategy -> forall A, TemplateMonad A
+| tmLemmaRed : ident -> option reductionStrategy -> forall A, TemplateMonad A
 
 (* Guarenteed to not cause "... already declared" error *)
 | tmFreshName : ident -> TemplateMonad ident
@@ -317,3 +317,7 @@ Inductive TemplateMonad : Type -> Type :=
 
 Instance TemplateMonad_Monad : Monad TemplateMonad :=
   {| ret := @tmReturn ; bind := @tmBind |}.
+
+Definition tmLemma (i : ident) := tmLemmaRed i (Some hnf).
+Definition tmAxiom (i : ident) := tmAxiomRed i (Some hnf).
+Definition tmDefinition (i : ident) {A : Type} := @tmDefinitionRed i (Some hnf) A.


### PR DESCRIPTION
Currently, `tmDefinition` uses `hnf` reduction for the body. We have some use cases where we need to control this more, and there was already a comment that this should be customisable.

At the current stage, this can not be merged, because it breaks probably the complete test-suite. We would have to add `Some hnf` everywhere.

One way to go is to remove `tmLemma` and `tmDefinition`, add `tmLemmaRed` and `tmDefinitionRed` to the monad and do `Definition tmLemma n := tmLemmaRed n (Some hnf).`.

Another way to go could be to define `Definition optReduction := option reduction_strategy.` with `Existing Class optReduction.` and `Instance defaultRed : optReduction := Some hnf.` but I think the other suggestions is cleaner.

I can discuss tomorrow with Matthieu and Simon, but wanted to open the pull request as possibility do discuss as well.