### PR TITLE
Implemented tmInferInstance

### DIFF
--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -154,11 +154,11 @@ struct
   let (tglobal_reference, tConstRef, tIndRef, tConstructRef) = (r_reify "global_reference", r_reify "ConstRef", r_reify "IndRef", r_reify "ConstructRef")
 
   let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinition, tmAxiom, tmLemma, tmFreshName, tmAbout, tmCurrentModPath,
-       tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped, tmExistingInstance) =
+       tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped, tmInferInstance, tmExistingInstance) =
     (r_reify "tmReturn", r_reify "tmBind", r_reify "tmQuote", r_reify "tmQuoteRec", r_reify "tmEval", r_reify "tmDefinition",
      r_reify "tmAxiom", r_reify "tmLemma", r_reify "tmFreshName", r_reify "tmAbout", r_reify "tmCurrentModPath",
      r_reify "tmMkDefinition", r_reify "tmMkInductive", r_reify "tmPrint", r_reify "tmFail", r_reify "tmQuoteInductive", r_reify "tmQuoteConstant",
-     r_reify "tmQuoteUniverses", r_reify "tmUnquote", r_reify "tmUnquoteTyped", r_reify "tmExistingInstance")
+     r_reify "tmQuoteUniverses", r_reify "tmUnquote", r_reify "tmUnquoteTyped", r_reify "tmInferInstance", r_reify "tmExistingInstance")
 
   (* let pkg_specif = ["Coq";"Init";"Specif"] *)
   (* let texistT = resolve_symbol pkg_specif "existT" *)

--- a/template-coq/src/constr_quoter.ml
+++ b/template-coq/src/constr_quoter.ml
@@ -154,11 +154,11 @@ struct
   let (tglobal_reference, tConstRef, tIndRef, tConstructRef) = (r_reify "global_reference", r_reify "ConstRef", r_reify "IndRef", r_reify "ConstructRef")
 
   let (tmReturn, tmBind, tmQuote, tmQuoteRec, tmEval, tmDefinition, tmAxiom, tmLemma, tmFreshName, tmAbout, tmCurrentModPath,
-       tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped) =
+       tmMkDefinition, tmMkInductive, tmPrint, tmFail, tmQuoteInductive, tmQuoteConstant, tmQuoteUniverses, tmUnquote, tmUnquoteTyped, tmExistingInstance) =
     (r_reify "tmReturn", r_reify "tmBind", r_reify "tmQuote", r_reify "tmQuoteRec", r_reify "tmEval", r_reify "tmDefinition",
      r_reify "tmAxiom", r_reify "tmLemma", r_reify "tmFreshName", r_reify "tmAbout", r_reify "tmCurrentModPath",
      r_reify "tmMkDefinition", r_reify "tmMkInductive", r_reify "tmPrint", r_reify "tmFail", r_reify "tmQuoteInductive", r_reify "tmQuoteConstant",
-     r_reify "tmQuoteUniverses", r_reify "tmUnquote", r_reify "tmUnquoteTyped")
+     r_reify "tmQuoteUniverses", r_reify "tmUnquote", r_reify "tmUnquoteTyped", r_reify "tmExistingInstance")
 
   (* let pkg_specif = ["Coq";"Init";"Specif"] *)
   (* let texistT = resolve_symbol pkg_specif "existT" *)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -703,4 +703,14 @@ let rec run_template_program_rec (k : Evd.evar_map * Constr.t -> unit)  ((evm, p
     match args with
     | name :: [] -> Classes.existing_instance true (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident (unquote_ident name)))) None
     | _ -> monad_failure "tmExistingInstance" 1
+  else if Constr.equal coConstr tmInferInstance then
+    match args with
+    | typ :: [] ->
+       (try
+          let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
+          k (evm, Term.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+        with
+          Not_found -> k (evm, Term.mkApp (cNone, [|typ|]))
+       )
+    | _ -> monad_failure "tmInferInstance" 1
   else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -699,4 +699,8 @@ let rec run_template_program_rec (k : Evd.evar_map * Constr.t -> unit)  ((evm, p
     | name::[] -> let name' = Namegen.next_ident_away_from (unquote_ident name) (fun id -> Nametab.exists_cci (Lib.make_path id)) in
                   k (evm, quote_ident name')
     | _ -> monad_failure "tmFreshName" 1
+  else if Constr.equal coConstr tmExistingInstance then
+    match args with
+    | name :: [] -> Classes.existing_instance true (CAst.make (Libnames.Qualid (Libnames.qualid_of_ident (unquote_ident name)))) None
+    | _ -> monad_failure "tmExistingInstance" 1
   else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/src/denote.ml
+++ b/template-coq/src/denote.ml
@@ -708,9 +708,9 @@ let rec run_template_program_rec (k : Evd.evar_map * Constr.t -> unit)  ((evm, p
     | typ :: [] ->
        (try
           let (evm,t) = Typeclasses.resolve_one_typeclass env evm (EConstr.of_constr typ) in
-          k (evm, Term.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
+          k (evm, Constr.mkApp (cSome, [| typ; EConstr.to_constr evm t|]))
         with
-          Not_found -> k (evm, Term.mkApp (cNone, [|typ|]))
+          Not_found -> k (evm, Constr.mkApp (cNone, [|typ|]))
        )
     | _ -> monad_failure "tmInferInstance" 1
   else CErrors.user_err (str "Invalid argument or not yet implemented. The argument must be a TemplateProgram: " ++ pr_constr coConstr)

--- a/template-coq/theories/Ast.v
+++ b/template-coq/theories/Ast.v
@@ -311,6 +311,7 @@ Inductive TemplateMonad : Type -> Type :=
 
 (* Not yet implemented *)
 | tmExistingInstance : ident -> TemplateMonad unit
+| tmInferInstance : forall A, TemplateMonad (option A)
 .
 
 (** This allow to use notations of MonadNotation *)

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -24,3 +24,4 @@ opaque.v
 proj.v
 TypingTests.v
 univ.v
+tmInferInstance.v

--- a/test-suite/tmExistingInstance.v
+++ b/test-suite/tmExistingInstance.v
@@ -1,0 +1,11 @@
+Require Import Template.All.
+Require Export String List.
+
+Fail Run TemplateProgram (tmExistingInstance "I").
+
+Existing Class True.
+
+Run TemplateProgram (tmExistingInstance "I").
+Print Instances True.
+
+

--- a/test-suite/tmInferInstance.v
+++ b/test-suite/tmInferInstance.v
@@ -1,0 +1,10 @@
+Require Import Template.All.
+Require Export String List.
+
+Import MonadNotation.
+
+Existing Class True.
+Existing Instance I.
+
+Run TemplateProgram (tmInferInstance True >>= tmDefinition "bla" None).
+

--- a/test-suite/tmInferInstance.v
+++ b/test-suite/tmInferInstance.v
@@ -6,5 +6,5 @@ Import MonadNotation.
 Existing Class True.
 Existing Instance I.
 
-Run TemplateProgram (tmInferInstance True >>= tmDefinition "bla" None).
-
+Run TemplateProgram (tmInferInstance True >>= tmPrint).
+Run TemplateProgram (tmInferInstance False >>= tmPrint).


### PR DESCRIPTION
I implemented the (probably) most straightforward way to get #23 closed (I named the new operation `tmInferInstance` to distinguish it better from `tmExistingInstance`)

`tmInferInstance` is returning an option instead of raising an error, so a user can recover if no instances are found and for instance use `tmLemma` instead.