### PR TITLE
Fix implicit arguments in tmLemma (#27)

### DIFF
--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1713,7 +1713,6 @@ struct
          let (evm, typ) = reduce_hnf env evm typ in
          let kind = (Decl_kinds.Global, Flags.use_polymorphic_flag (), Decl_kinds.Definition) in
          let (evm, hole) = Evarutil.new_evar env evm (EConstr.of_constr typ) in
-         (* let typ = Constrextern.extern_type true env evm (EConstr.of_constr typ) in *)
          let original_program_flag = !Flags.program_mode in
          Flags.program_mode := true;
          do_definition (unquote_ident name) evm kind None (EConstr.to_constr evm hole) typ

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1664,13 +1664,9 @@ struct
        str "Please file a bug with Template-Coq.")
 
 
-  let do_definition ident k pl c typ hook evm =
-    let evd = evm in
+  let do_definition ident evd k pl c typ hook =
     let env = Global.env () in
-    (* let (c,ctx), sideff = Future.force ce.const_entry_body in *)
-    (* assert(Safe_typing.empty_private_constants = sideff); *)
-    (* assert(Univ.ContextSet.is_empty ctx); *)
-    Obligations.check_evars env evd;
+    (* Obligations.check_evars env evd; *)
     let obls, _, c, cty = 
       Obligations.eterm_obligations env ident evd 0 c typ
     in
@@ -1720,7 +1716,7 @@ struct
          (* let typ = Constrextern.extern_type true env evm (EConstr.of_constr typ) in *)
          let original_program_flag = !Flags.program_mode in
          Flags.program_mode := true;
-         do_definition (unquote_ident name) kind None (EConstr.to_constr evm hole) typ
+         do_definition (unquote_ident name) evm kind None (EConstr.to_constr evm hole) typ
                                (Lemmas.mk_hook (fun _ gr -> let env = Global.env () in
                                                             let evm, t = Evd.fresh_global env evm gr in k (evm, t)));
          Flags.program_mode := original_program_flag

--- a/src/reify.ml4
+++ b/src/reify.ml4
@@ -1666,7 +1666,6 @@ struct
 
   let do_definition ident evd k pl c typ hook =
     let env = Global.env () in
-    (* Obligations.check_evars env evd; *)
     let obls, _, c, cty = 
       Obligations.eterm_obligations env ident evd 0 c typ
     in
@@ -1712,10 +1711,11 @@ struct
          let (evm, name) = reduce_all env evm name in
          let (evm, typ) = reduce_hnf env evm typ in
          let kind = (Decl_kinds.Global, Flags.use_polymorphic_flag (), Decl_kinds.Definition) in
-         let (evm, hole) = Evarutil.new_evar env evm (EConstr.of_constr typ) in
+         let (evd, hole) = Evarutil.new_evar env evm (EConstr.of_constr typ) in
          let original_program_flag = !Flags.program_mode in
          Flags.program_mode := true;
-         do_definition (unquote_ident name) evm kind None (EConstr.to_constr evm hole) typ
+         Obligations.check_evars env evm;
+         do_definition (unquote_ident name) evd kind None (EConstr.to_constr evm hole) typ
                                (Lemmas.mk_hook (fun _ gr -> let env = Global.env () in
                                                             let evm, t = Evd.fresh_global env evm gr in k (evm, t)));
          Flags.program_mode := original_program_flag

--- a/test-suite/tmLemmaBug.v
+++ b/test-suite/tmLemmaBug.v
@@ -1,0 +1,10 @@
+Require Import Template.All.
+Require Export String List.
+
+Run TemplateProgram (tmLemma "test1" nat).
+Next Obligation.
+  exact 0.
+Qed.
+  
+Run TemplateProgram (tmLemma "test" (@nil nat = nil)).
+


### PR DESCRIPTION
Fix for #27 

Previously, the argument for `tmLemma` was externalised, which lost explicitly passed implicit arguments. `Command.do_definition` does not accept `constr` directly, so I copy-pasted it into a new definition. 

The `hole` is now a new evar. I moved `check_evars` to only check the evar map without the new evar.