### PR TITLE
Make Template Check able to check a term (and not only a reference).

### DIFF
--- a/checker/demo.v
+++ b/checker/demo.v
@@ -1,3 +1,6 @@
 Require Import TemplateChecker.Loader.
 
-Template Check Nat.add.
+Template Check (3 + 9).
+
+Require Import Reals.
+Template Check Rplus.


### PR DESCRIPTION
Note that `Template Check` still cannot typecheck a not typable term because of pretyping.
To allow this, we would need a function glob_constr -> constr which doesn't pretype.