### PR TITLE
Type in type fix

### DIFF
--- a/template-coq/theories/Typing.v
+++ b/template-coq/theories/Typing.v
@@ -283,8 +283,7 @@ Fixpoint subst_app (t : term) (us : list term) : term :=
 
 (** We try syntactic equality before checking the graph. *)
 
-Definition eq_universe φ s s' :=
-  let cf := default_checker_flags in
+Definition eq_universe `{checker_flags} φ s s' :=
   if univ.Universe.equal s s' then true
   else uGraph.check_leq φ s s' && uGraph.check_leq φ s' s.
 

--- a/template-coq/theories/config.v
+++ b/template-coq/theories/config.v
@@ -7,3 +7,7 @@ Class checker_flags := {
 Local Instance default_checker_flags : checker_flags := {|
   check_univs := true
 |}.
+
+Local Instance type_in_type : checker_flags := {|
+  check_univs := false
+|}.


### PR DESCRIPTION
My previous type-in-type pull request was incomplete.
`check_leq` was indeed relying on the configuration, but `eq_universe` was not. This PR should fix it.