### PR TITLE
Run template programs in tactics

### DIFF
--- a/template-coq/src/g_template_coq.ml4
+++ b/template-coq/src/g_template_coq.ml4
@@ -150,6 +150,20 @@ VERNAC COMMAND EXTEND Run_program CLASSIFIED AS SIDEFF
         Denote.run_template_program_rec (fun _ -> ()) (evm, (EConstr.to_constr evm def)) ]
 END;;
 
+TACTIC EXTEND run_program
+    | [ "run_template_program" constr(c) tactic(tac) ] ->
+      [ Proofview.Goal.enter (begin fun gl ->
+         let env = Proofview.Goal.env gl in
+         let evm = Proofview.Goal.sigma gl in
+         let ret = ref None in
+         Denote.run_template_program_rec ~intactic:true (fun (evm, t) -> ret := Some t) (evm, EConstr.to_constr evm c);
+         match !ret with
+           Some c ->
+           ltac_apply tac (List.map to_ltac_val [EConstr.of_constr c])
+         | None -> Proofview.tclUNIT ()
+       end) ]
+END;;
+
 VERNAC COMMAND EXTEND Make_tests CLASSIFIED AS QUERY
     | [ "Test" "Quote" constr(c) ] ->
       [ let (evm,env) = Pfedit.get_current_context () in

--- a/test-suite/run_in_tactic.v
+++ b/test-suite/run_in_tactic.v
@@ -5,4 +5,7 @@ Import ListNotations MonadNotation.
 Goal True.
   let k x := pose (y := x) in
   run_template_program (tmPrint "test" ;; tmQuote plus) k.
+
+  Fail let k x := pose (y := x) in
+  run_template_program (tmLemma "test" nat) k.
 Abort.

--- a/test-suite/run_in_tactic.v
+++ b/test-suite/run_in_tactic.v
@@ -1,0 +1,8 @@
+Require Import Template.All.
+Require Import List String.
+Import ListNotations MonadNotation.
+
+Goal True.
+  let k x := pose (y := x) in
+  run_template_program (tmPrint "test" ;; tmQuote plus) k.
+Abort.


### PR DESCRIPTION
I ported my local fixes to 8.8. There's a `run_template_program p k` now where `p` is the program and `k` the continuation tactic to run on the result. There's a very basic `run_in_tactics.v` test case